### PR TITLE
feat: Phase 2 - Core UX (tabbed requests, key-value editors, response…

### DIFF
--- a/frontend/src/__tests__/components.test.tsx
+++ b/frontend/src/__tests__/components.test.tsx
@@ -51,6 +51,6 @@ describe('Sidebar', () => {
 
   it('renders version footer', () => {
     renderWithRouter(<Sidebar />);
-    expect(screen.getByText('API-Watch v1.0')).toBeInTheDocument();
+    expect(screen.getByText('API-Watch v2.0')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/BodyEditor.tsx
+++ b/frontend/src/components/BodyEditor.tsx
@@ -1,0 +1,105 @@
+import { cn } from '../lib/utils';
+import KeyValueEditor from './KeyValueEditor';
+import type { BodyType, KeyValuePair } from '../store/useRequestStore';
+import type { HttpMethod } from '../store/useRequestStore';
+
+interface BodyEditorProps {
+  method: HttpMethod;
+  bodyType: BodyType;
+  bodyRaw: string;
+  bodyFormData: KeyValuePair[];
+  onBodyTypeChange: (type: BodyType) => void;
+  onBodyRawChange: (raw: string) => void;
+  onBodyFormDataChange: (pairs: KeyValuePair[]) => void;
+}
+
+const bodyTypes: { value: BodyType; label: string }[] = [
+  { value: 'none', label: 'None' },
+  { value: 'json', label: 'JSON' },
+  { value: 'text', label: 'Text' },
+  { value: 'xml', label: 'XML' },
+  { value: 'form-data', label: 'Form Data' },
+  { value: 'x-www-form-urlencoded', label: 'URL Encoded' },
+];
+
+const rawPlaceholders: Record<string, string> = {
+  json: `{
+  "key": "value",
+  "items": [1, 2, 3]
+}`,
+  text: 'Plain text body content...',
+  xml: `<?xml version="1.0"?>
+<root>
+  <item>value</item>
+</root>`,
+};
+
+export default function BodyEditor({
+  method,
+  bodyType,
+  bodyRaw,
+  bodyFormData,
+  onBodyTypeChange,
+  onBodyRawChange,
+  onBodyFormDataChange,
+}: BodyEditorProps) {
+  const noBody = method === 'GET' || method === 'HEAD';
+
+  if (noBody) {
+    return (
+      <div className="flex items-center justify-center py-8 text-xs text-surface-400">
+        {method} requests typically don&apos;t have a body
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Type selector */}
+      <div className="flex items-center gap-1 flex-wrap">
+        {bodyTypes.map((bt) => (
+          <button
+            key={bt.value}
+            onClick={() => onBodyTypeChange(bt.value)}
+            className={cn(
+              'px-2.5 py-1 rounded-lg text-[11px] font-medium transition-colors',
+              bodyType === bt.value
+                ? 'bg-brand-100 text-brand-700 dark:bg-brand-900/30 dark:text-brand-400'
+                : 'bg-surface-100 dark:bg-surface-800 text-surface-500 hover:bg-surface-200 dark:hover:bg-surface-700'
+            )}
+          >
+            {bt.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Body content */}
+      {bodyType === 'none' && (
+        <div className="flex items-center justify-center py-6 text-xs text-surface-400">
+          No body content for this request
+        </div>
+      )}
+
+      {(bodyType === 'json' || bodyType === 'text' || bodyType === 'xml') && (
+        <textarea
+          value={bodyRaw}
+          onChange={(e) => onBodyRawChange(e.target.value)}
+          placeholder={rawPlaceholders[bodyType] || ''}
+          className="input font-mono text-xs !rounded-xl leading-relaxed"
+          rows={10}
+          spellCheck={false}
+        />
+      )}
+
+      {(bodyType === 'form-data' || bodyType === 'x-www-form-urlencoded') && (
+        <KeyValueEditor
+          pairs={bodyFormData}
+          onChange={onBodyFormDataChange}
+          keyPlaceholder="Field"
+          valuePlaceholder="Value"
+          allowBulkEdit={false}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/CollectionsSidebar.tsx
+++ b/frontend/src/components/CollectionsSidebar.tsx
@@ -1,0 +1,275 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  FolderOpen,
+  ChevronRight,
+  ChevronDown,
+  Plus,
+  Trash2,
+  Loader2,
+  FolderPlus,
+  X,
+} from 'lucide-react';
+import { cn } from '../lib/utils';
+import apiClient from '../lib/api';
+import { useRequestStore } from '../store/useRequestStore';
+import type { HttpMethod, KeyValuePair } from '../store/useRequestStore';
+import { uid } from '../store/useRequestStore';
+
+interface SavedRequest {
+  id: string;
+  name: string;
+  method: string;
+  url: string;
+  headers: string | null;
+  params: string | null;
+  body: string | null;
+  body_type: string | null;
+  timeout: number;
+}
+
+interface Collection {
+  id: string;
+  name: string;
+  description: string | null;
+  requests: SavedRequest[];
+}
+
+const methodBadgeColors: Record<string, string> = {
+  GET: 'text-emerald-600 dark:text-emerald-400',
+  POST: 'text-blue-600 dark:text-blue-400',
+  PUT: 'text-amber-600 dark:text-amber-400',
+  DELETE: 'text-red-600 dark:text-red-400',
+  PATCH: 'text-purple-600 dark:text-purple-400',
+};
+
+export default function CollectionsSidebar() {
+  const { addTab } = useRequestStore();
+  const [collections, setCollections] = useState<Collection[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [showNewCollection, setShowNewCollection] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const fetchCollections = useCallback(async () => {
+    try {
+      const res = await apiClient.get('/api/v1/collections');
+      setCollections(res.data);
+    } catch {
+      // Not authenticated or error - show empty
+      setCollections([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCollections();
+  }, [fetchCollections]);
+
+  const toggleExpand = (id: string) => {
+    setExpandedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const createCollection = async () => {
+    if (!newName.trim()) return;
+    setCreating(true);
+    try {
+      await apiClient.post('/api/v1/collections', { name: newName.trim() });
+      setNewName('');
+      setShowNewCollection(false);
+      fetchCollections();
+    } catch {
+      // ignore
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const deleteCollection = async (id: string) => {
+    try {
+      await apiClient.delete(`/api/v1/collections/${id}`);
+      fetchCollections();
+    } catch {
+      // ignore
+    }
+  };
+
+  const openRequestInTab = (req: SavedRequest, collectionId: string) => {
+    let parsedHeaders: KeyValuePair[] = [{ id: uid(), key: '', value: '', enabled: true }];
+    let parsedParams: KeyValuePair[] = [{ id: uid(), key: '', value: '', enabled: true }];
+
+    if (req.headers) {
+      try {
+        const h = JSON.parse(req.headers);
+        const entries = Object.entries(h).map(([key, value]) => ({
+          id: uid(),
+          key,
+          value: String(value),
+          enabled: true,
+        }));
+        if (entries.length > 0) {
+          parsedHeaders = [...entries, { id: uid(), key: '', value: '', enabled: true }];
+        }
+      } catch {
+        // keep default
+      }
+    }
+
+    if (req.params) {
+      try {
+        const p = JSON.parse(req.params);
+        const entries = Object.entries(p).map(([key, value]) => ({
+          id: uid(),
+          key,
+          value: String(value),
+          enabled: true,
+        }));
+        if (entries.length > 0) {
+          parsedParams = [...entries, { id: uid(), key: '', value: '', enabled: true }];
+        }
+      } catch {
+        // keep default
+      }
+    }
+
+    addTab({
+      name: req.name,
+      method: req.method as HttpMethod,
+      url: req.url,
+      headers: parsedHeaders,
+      params: parsedParams,
+      bodyType: (req.body_type as any) || 'none',
+      bodyRaw: req.body || '',
+      timeout: req.timeout || 10,
+      savedRequestId: req.id,
+      collectionId,
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      {/* Header */}
+      <div className="flex items-center justify-between px-1 mb-1">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-surface-400 dark:text-surface-500">
+          Collections
+        </span>
+        <button
+          onClick={() => setShowNewCollection(!showNewCollection)}
+          className="p-1 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-800 text-surface-400 hover:text-surface-600 transition-colors"
+          title="New collection"
+        >
+          <FolderPlus className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {/* New collection input */}
+      {showNewCollection && (
+        <div className="flex items-center gap-1 px-1">
+          <input
+            type="text"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') createCollection(); if (e.key === 'Escape') setShowNewCollection(false); }}
+            placeholder="Collection name"
+            className="input !py-1 text-xs flex-1"
+            autoFocus
+          />
+          <button
+            onClick={createCollection}
+            disabled={creating || !newName.trim()}
+            className="p-1 rounded-lg bg-brand-600 text-white hover:bg-brand-700 disabled:opacity-50"
+          >
+            {creating ? <Loader2 className="w-3 h-3 animate-spin" /> : <Plus className="w-3 h-3" />}
+          </button>
+          <button
+            onClick={() => { setShowNewCollection(false); setNewName(''); }}
+            className="p-1 rounded-lg text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800"
+          >
+            <X className="w-3 h-3" />
+          </button>
+        </div>
+      )}
+
+      {/* Collections list */}
+      {loading ? (
+        <div className="flex items-center justify-center py-4">
+          <Loader2 className="w-4 h-4 text-surface-400 animate-spin" />
+        </div>
+      ) : collections.length === 0 ? (
+        <div className="text-center py-4">
+          <FolderOpen className="w-5 h-5 text-surface-300 dark:text-surface-600 mx-auto mb-1" />
+          <p className="text-[10px] text-surface-400">No collections yet</p>
+        </div>
+      ) : (
+        <div className="space-y-0.5">
+          {collections.map((col) => {
+            const isExpanded = expandedIds.has(col.id);
+            return (
+              <div key={col.id}>
+                {/* Collection header */}
+                <div className="group flex items-center gap-1.5 px-1.5 py-1.5 rounded-lg hover:bg-surface-50 dark:hover:bg-surface-800/50 cursor-pointer transition-colors">
+                  <button onClick={() => toggleExpand(col.id)} className="flex items-center gap-1.5 flex-1 min-w-0">
+                    {isExpanded ? (
+                      <ChevronDown className="w-3 h-3 text-surface-400 flex-shrink-0" />
+                    ) : (
+                      <ChevronRight className="w-3 h-3 text-surface-400 flex-shrink-0" />
+                    )}
+                    <FolderOpen className="w-3.5 h-3.5 text-brand-500 flex-shrink-0" />
+                    <span className="text-xs font-medium text-surface-700 dark:text-surface-300 truncate">
+                      {col.name}
+                    </span>
+                    {col.requests.length > 0 && (
+                      <span className="text-[10px] text-surface-400 flex-shrink-0">
+                        ({col.requests.length})
+                      </span>
+                    )}
+                  </button>
+                  <button
+                    onClick={() => deleteCollection(col.id)}
+                    className="p-0.5 rounded opacity-0 group-hover:opacity-100 text-surface-400 hover:text-red-500 transition-opacity"
+                    title="Delete collection"
+                  >
+                    <Trash2 className="w-3 h-3" />
+                  </button>
+                </div>
+
+                {/* Requests */}
+                {isExpanded && (
+                  <div className="ml-4 pl-2 border-l border-surface-200 dark:border-surface-700/50 space-y-0.5 mt-0.5">
+                    {col.requests.length === 0 ? (
+                      <p className="text-[10px] text-surface-400 px-2 py-1">No requests</p>
+                    ) : (
+                      col.requests.map((req) => (
+                        <button
+                          key={req.id}
+                          onClick={() => openRequestInTab(req, col.id)}
+                          className="w-full flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-surface-50 dark:hover:bg-surface-800/50 transition-colors text-left group"
+                        >
+                          <span className={cn(
+                            'text-[9px] font-bold uppercase tracking-wide w-8 flex-shrink-0',
+                            methodBadgeColors[req.method] || 'text-surface-500'
+                          )}>
+                            {req.method}
+                          </span>
+                          <span className="text-[11px] text-surface-600 dark:text-surface-400 truncate">
+                            {req.name}
+                          </span>
+                        </button>
+                      ))
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/EnvironmentSelector.tsx
+++ b/frontend/src/components/EnvironmentSelector.tsx
@@ -1,0 +1,286 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Globe,
+  ChevronDown,
+  Plus,
+  X,
+  Loader2,
+  Check,
+  Pencil,
+} from 'lucide-react';
+import { cn } from '../lib/utils';
+import apiClient from '../lib/api';
+
+interface Environment {
+  id: string;
+  name: string;
+  variables: Record<string, string>;
+  is_active: boolean;
+}
+
+export default function EnvironmentSelector() {
+  const [environments, setEnvironments] = useState<Environment[]>([]);
+  const [activeEnv, setActiveEnv] = useState<Environment | null>(null);
+  const [isOpen, setIsOpen] = useState(false);
+  const [showEditor, setShowEditor] = useState(false);
+  const [editorEnv, setEditorEnv] = useState<Environment | null>(null);
+  const [newName, setNewName] = useState('');
+  const [newVars, setNewVars] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const fetchEnvironments = useCallback(async () => {
+    try {
+      const res = await apiClient.get('/api/v1/environments');
+      setEnvironments(res.data);
+      const active = res.data.find((e: Environment) => e.is_active);
+      setActiveEnv(active || null);
+    } catch {
+      setEnvironments([]);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchEnvironments();
+  }, [fetchEnvironments]);
+
+  const selectEnvironment = async (env: Environment) => {
+    try {
+      await apiClient.put(`/api/v1/environments/${env.id}`, {
+        name: env.name,
+        variables: env.variables,
+        is_active: true,
+      });
+      setIsOpen(false);
+      fetchEnvironments();
+    } catch {
+      // ignore
+    }
+  };
+
+  const deactivateAll = async () => {
+    if (!activeEnv) return;
+    try {
+      await apiClient.put(`/api/v1/environments/${activeEnv.id}`, {
+        name: activeEnv.name,
+        variables: activeEnv.variables,
+        is_active: false,
+      });
+      setIsOpen(false);
+      fetchEnvironments();
+    } catch {
+      // ignore
+    }
+  };
+
+  const openEditor = (env?: Environment) => {
+    if (env) {
+      setEditorEnv(env);
+      setNewName(env.name);
+      setNewVars(
+        Object.entries(env.variables)
+          .map(([k, v]) => `${k}=${v}`)
+          .join('\n')
+      );
+    } else {
+      setEditorEnv(null);
+      setNewName('');
+      setNewVars('');
+    }
+    setShowEditor(true);
+    setIsOpen(false);
+  };
+
+  const parseVars = (text: string): Record<string, string> => {
+    const vars: Record<string, string> = {};
+    text.split('\n').forEach((line) => {
+      const idx = line.indexOf('=');
+      if (idx > 0) {
+        vars[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+      }
+    });
+    return vars;
+  };
+
+  const saveEnvironment = async () => {
+    if (!newName.trim()) return;
+    setSaving(true);
+    try {
+      const variables = parseVars(newVars);
+      if (editorEnv) {
+        await apiClient.put(`/api/v1/environments/${editorEnv.id}`, {
+          name: newName.trim(),
+          variables,
+          is_active: editorEnv.is_active,
+        });
+      } else {
+        await apiClient.post('/api/v1/environments', {
+          name: newName.trim(),
+          variables,
+        });
+      }
+      setShowEditor(false);
+      fetchEnvironments();
+    } catch {
+      // ignore
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const deleteEnvironment = async (id: string) => {
+    try {
+      await apiClient.delete(`/api/v1/environments/${id}`);
+      setShowEditor(false);
+      fetchEnvironments();
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <>
+      {/* Dropdown trigger */}
+      <div className="relative">
+        <button
+          onClick={() => setIsOpen(!isOpen)}
+          className={cn(
+            'flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-colors border',
+            activeEnv
+              ? 'bg-emerald-50 dark:bg-emerald-900/20 border-emerald-200/50 dark:border-emerald-800/30 text-emerald-700 dark:text-emerald-400'
+              : 'bg-surface-100 dark:bg-surface-800 border-surface-200 dark:border-surface-700 text-surface-500'
+          )}
+        >
+          <Globe className="w-3 h-3" />
+          <span className="max-w-[100px] truncate">{activeEnv?.name || 'No Env'}</span>
+          <ChevronDown className={cn('w-3 h-3 transition-transform', isOpen && 'rotate-180')} />
+        </button>
+
+        {/* Dropdown */}
+        {isOpen && (
+          <>
+            <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
+            <div className="absolute top-full right-0 mt-1 z-50 bg-white dark:bg-surface-800 border border-surface-200 dark:border-surface-700 rounded-xl shadow-lg py-1 min-w-[180px]">
+              {/* No environment option */}
+              <button
+                onClick={deactivateAll}
+                className={cn(
+                  'w-full px-3 py-1.5 text-left text-xs flex items-center gap-2 hover:bg-surface-50 dark:hover:bg-surface-700/50',
+                  !activeEnv ? 'text-brand-600 font-medium' : 'text-surface-500'
+                )}
+              >
+                {!activeEnv && <Check className="w-3 h-3" />}
+                <span className={!activeEnv ? '' : 'ml-5'}>No Environment</span>
+              </button>
+
+              <div className="border-t border-surface-100 dark:border-surface-700/50 my-1" />
+
+              {environments.map((env) => (
+                <div key={env.id} className="flex items-center group">
+                  <button
+                    onClick={() => selectEnvironment(env)}
+                    className={cn(
+                      'flex-1 px-3 py-1.5 text-left text-xs flex items-center gap-2 hover:bg-surface-50 dark:hover:bg-surface-700/50',
+                      env.is_active ? 'text-emerald-600 dark:text-emerald-400 font-medium' : 'text-surface-600 dark:text-surface-300'
+                    )}
+                  >
+                    {env.is_active && <Check className="w-3 h-3" />}
+                    <span className={env.is_active ? '' : 'ml-5'}>{env.name}</span>
+                    <span className="text-[10px] text-surface-400 ml-auto">
+                      {Object.keys(env.variables).length} vars
+                    </span>
+                  </button>
+                  <button
+                    onClick={() => openEditor(env)}
+                    className="p-1 mr-1 rounded opacity-0 group-hover:opacity-100 text-surface-400 hover:text-brand-500 transition-opacity"
+                  >
+                    <Pencil className="w-3 h-3" />
+                  </button>
+                </div>
+              ))}
+
+              <div className="border-t border-surface-100 dark:border-surface-700/50 my-1" />
+
+              <button
+                onClick={() => openEditor()}
+                className="w-full px-3 py-1.5 text-left text-xs text-brand-600 dark:text-brand-400 hover:bg-brand-50 dark:hover:bg-brand-900/10 flex items-center gap-2"
+              >
+                <Plus className="w-3 h-3" />
+                New Environment
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Editor Modal */}
+      {showEditor && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <div className="fixed inset-0 bg-black/40 backdrop-blur-sm" onClick={() => setShowEditor(false)} />
+          <div className="relative bg-white dark:bg-surface-800 rounded-2xl shadow-xl w-full max-w-md overflow-hidden">
+            <div className="flex items-center justify-between px-5 py-3 border-b border-surface-100 dark:border-surface-700/50">
+              <h3 className="text-sm font-semibold text-surface-900 dark:text-white">
+                {editorEnv ? 'Edit Environment' : 'New Environment'}
+              </h3>
+              <button onClick={() => setShowEditor(false)} className="p-1 rounded-lg hover:bg-surface-100 dark:hover:bg-surface-700">
+                <X className="w-4 h-4 text-surface-400" />
+              </button>
+            </div>
+
+            <div className="p-5 space-y-3">
+              <div>
+                <label className="text-xs font-medium text-surface-500 mb-1 block">Name</label>
+                <input
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  placeholder="Development"
+                  className="input text-sm"
+                  autoFocus
+                />
+              </div>
+              <div>
+                <label className="text-xs font-medium text-surface-500 mb-1 block">
+                  Variables <span className="text-surface-400 font-normal">(KEY=VALUE, one per line)</span>
+                </label>
+                <textarea
+                  value={newVars}
+                  onChange={(e) => setNewVars(e.target.value)}
+                  placeholder={'BASE_URL=https://api.example.com\nAPI_KEY=your-key-here\nTOKEN=abc123'}
+                  className="input font-mono text-xs !rounded-xl"
+                  rows={6}
+                />
+                <p className="text-[10px] text-surface-400 mt-1">
+                  {'Use {{VARIABLE_NAME}} in your requests to interpolate'}
+                </p>
+              </div>
+            </div>
+
+            <div className="px-5 py-3 border-t border-surface-100 dark:border-surface-700/50 flex items-center justify-between">
+              <div>
+                {editorEnv && (
+                  <button
+                    onClick={() => deleteEnvironment(editorEnv.id)}
+                    className="btn-ghost !py-1.5 !px-3 !text-xs text-red-500 hover:text-red-600"
+                  >
+                    Delete
+                  </button>
+                )}
+              </div>
+              <div className="flex gap-2">
+                <button onClick={() => setShowEditor(false)} className="btn-secondary !py-1.5 !text-xs">
+                  Cancel
+                </button>
+                <button
+                  onClick={saveEnvironment}
+                  disabled={saving || !newName.trim()}
+                  className="btn-primary !py-1.5 !text-xs"
+                >
+                  {saving ? <Loader2 className="w-3 h-3 animate-spin" /> : 'Save'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -2,6 +2,7 @@ import { Moon, Sun, Menu, Zap, LogOut, User } from 'lucide-react';
 import { useAppStore } from '../store/useAppStore';
 import { useAuthStore } from '../store/useAuthStore';
 import { useNavigate } from 'react-router-dom';
+import EnvironmentSelector from './EnvironmentSelector';
 
 export default function Header() {
   const { darkMode, toggleDarkMode, toggleSidebar } = useAppStore();
@@ -38,8 +39,12 @@ export default function Header() {
           </div>
 
           {/* Right */}
-          <div className="flex items-center gap-1">
-            <div className="hidden sm:flex items-center gap-1.5 mr-3 px-2.5 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200/50 dark:border-emerald-800/30">
+          <div className="flex items-center gap-2">
+            <div className="hidden sm:block">
+              <EnvironmentSelector />
+            </div>
+
+            <div className="hidden sm:flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200/50 dark:border-emerald-800/30">
               <div className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse-soft" />
               <span className="text-xs font-medium text-emerald-700 dark:text-emerald-400">Connected</span>
             </div>

--- a/frontend/src/components/KeyValueEditor.tsx
+++ b/frontend/src/components/KeyValueEditor.tsx
@@ -1,0 +1,181 @@
+import { Plus, X, ToggleLeft, ToggleRight, AlignJustify, Table2 } from 'lucide-react';
+import { useState } from 'react';
+import { cn } from '../lib/utils';
+import type { KeyValuePair } from '../store/useRequestStore';
+import { uid } from '../store/useRequestStore';
+
+interface KeyValueEditorProps {
+  pairs: KeyValuePair[];
+  onChange: (pairs: KeyValuePair[]) => void;
+  keyPlaceholder?: string;
+  valuePlaceholder?: string;
+  /** Show a "Bulk Edit" toggle (plain text mode) */
+  allowBulkEdit?: boolean;
+}
+
+export default function KeyValueEditor({
+  pairs,
+  onChange,
+  keyPlaceholder = 'Key',
+  valuePlaceholder = 'Value',
+  allowBulkEdit = true,
+}: KeyValueEditorProps) {
+  const [bulkMode, setBulkMode] = useState(false);
+
+  // ── Bulk edit text ↔ pairs conversion ──
+  const toBulkText = (): string =>
+    pairs
+      .filter((p) => p.key || p.value)
+      .map((p) => `${p.key}: ${p.value}`)
+      .join('\n');
+
+  const fromBulkText = (text: string): KeyValuePair[] => {
+    const result: KeyValuePair[] = text
+      .split('\n')
+      .filter((line) => line.includes(':'))
+      .map((line) => {
+        const idx = line.indexOf(':');
+        return {
+          id: uid(),
+          key: line.slice(0, idx).trim(),
+          value: line.slice(idx + 1).trim(),
+          enabled: true,
+        };
+      });
+    if (result.length === 0 || result[result.length - 1].key) {
+      result.push({ id: uid(), key: '', value: '', enabled: true });
+    }
+    return result;
+  };
+
+  const updatePair = (id: string, field: keyof KeyValuePair, value: string | boolean) => {
+    let updated = pairs.map((p) => (p.id === id ? { ...p, [field]: value } : p));
+    // Auto-add empty row at the end
+    const last = updated[updated.length - 1];
+    if (last && (last.key || last.value)) {
+      updated = [...updated, { id: uid(), key: '', value: '', enabled: true }];
+    }
+    onChange(updated);
+  };
+
+  const removePair = (id: string) => {
+    const updated = pairs.filter((p) => p.id !== id);
+    if (updated.length === 0) {
+      onChange([{ id: uid(), key: '', value: '', enabled: true }]);
+    } else {
+      onChange(updated);
+    }
+  };
+
+  const addPair = () => {
+    onChange([...pairs, { id: uid(), key: '', value: '', enabled: true }]);
+  };
+
+  if (bulkMode) {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-[10px] font-semibold text-surface-400 uppercase tracking-wider">Bulk Edit</span>
+          <button
+            onClick={() => setBulkMode(false)}
+            className="btn-ghost !py-1 !px-2 !text-[10px] gap-1"
+          >
+            <Table2 className="w-3 h-3" />
+            Table View
+          </button>
+        </div>
+        <textarea
+          defaultValue={toBulkText()}
+          onBlur={(e) => onChange(fromBulkText(e.target.value))}
+          placeholder={`${keyPlaceholder}: ${valuePlaceholder}\nContent-Type: application/json`}
+          className="input font-mono text-xs !rounded-xl"
+          rows={6}
+        />
+        <p className="text-[10px] text-surface-400">One pair per line, format: <code className="text-brand-500">key: value</code></p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {/* Header row */}
+      <div className="flex items-center justify-between mb-1">
+        <div className="flex items-center gap-4 flex-1">
+          <span className="text-[10px] font-semibold text-surface-400 uppercase tracking-wider w-5" />
+          <span className="text-[10px] font-semibold text-surface-400 uppercase tracking-wider flex-1">{keyPlaceholder}</span>
+          <span className="text-[10px] font-semibold text-surface-400 uppercase tracking-wider flex-1">{valuePlaceholder}</span>
+          <span className="w-7" />
+        </div>
+        {allowBulkEdit && (
+          <button
+            onClick={() => setBulkMode(true)}
+            className="btn-ghost !py-1 !px-2 !text-[10px] gap-1"
+          >
+            <AlignJustify className="w-3 h-3" />
+            Bulk Edit
+          </button>
+        )}
+      </div>
+
+      {/* Rows */}
+      {pairs.map((pair) => (
+        <div
+          key={pair.id}
+          className={cn(
+            'flex items-center gap-2 group transition-opacity',
+            !pair.enabled && 'opacity-40'
+          )}
+        >
+          {/* Enable/disable toggle */}
+          <button
+            onClick={() => updatePair(pair.id, 'enabled', !pair.enabled)}
+            className="p-0.5 rounded hover:bg-surface-100 dark:hover:bg-surface-800 flex-shrink-0"
+            title={pair.enabled ? 'Disable' : 'Enable'}
+          >
+            {pair.enabled ? (
+              <ToggleRight className="w-4 h-4 text-brand-500" />
+            ) : (
+              <ToggleLeft className="w-4 h-4 text-surface-400" />
+            )}
+          </button>
+
+          {/* Key */}
+          <input
+            type="text"
+            value={pair.key}
+            onChange={(e) => updatePair(pair.id, 'key', e.target.value)}
+            placeholder={keyPlaceholder}
+            className="input !py-1.5 text-xs font-mono flex-1"
+          />
+
+          {/* Value */}
+          <input
+            type="text"
+            value={pair.value}
+            onChange={(e) => updatePair(pair.id, 'value', e.target.value)}
+            placeholder={valuePlaceholder}
+            className="input !py-1.5 text-xs font-mono flex-1"
+          />
+
+          {/* Delete */}
+          <button
+            onClick={() => removePair(pair.id)}
+            className="p-1 rounded hover:bg-red-50 dark:hover:bg-red-900/10 text-surface-300 hover:text-red-500 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
+            title="Remove"
+          >
+            <X className="w-3.5 h-3.5" />
+          </button>
+        </div>
+      ))}
+
+      {/* Add row button */}
+      <button
+        onClick={addPair}
+        className="btn-ghost !py-1 !px-2 !text-[10px] text-brand-600 dark:text-brand-400 mt-1"
+      >
+        <Plus className="w-3 h-3" />
+        Add
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/ResponseViewer.tsx
+++ b/frontend/src/components/ResponseViewer.tsx
@@ -1,0 +1,264 @@
+import { useState, useMemo } from 'react';
+import {
+  Copy,
+  Check,
+  Download,
+  FileJson,
+  Code2,
+  CheckCircle,
+  XCircle,
+  WrapText,
+} from 'lucide-react';
+import { cn, formatDuration, formatBytes } from '../lib/utils';
+import type { TabResponse } from '../store/useRequestStore';
+
+interface ResponseViewerProps {
+  response: TabResponse;
+}
+
+type ResponseTab = 'body' | 'headers';
+
+/** Minimal JSON / XML syntax highlighter (no external deps) */
+function highlightJson(json: string): string {
+  return json
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    // strings
+    .replace(/"([^"\\]*(\\.[^"\\]*)*)"/g, (match, _inner) => {
+      // Check if this is a key (followed by :)
+      return `<span class="json-string">${match}</span>`;
+    })
+    // numbers
+    .replace(/\b(-?\d+\.?\d*([eE][+-]?\d+)?)\b/g, '<span class="json-number">$1</span>')
+    // booleans & null
+    .replace(/\b(true|false|null)\b/g, '<span class="json-keyword">$1</span>');
+}
+
+function formatAndHighlight(body: string): { formatted: string; language: string } {
+  // Try JSON
+  try {
+    const parsed = JSON.parse(body);
+    const formatted = JSON.stringify(parsed, null, 2);
+    return { formatted: highlightJson(formatted), language: 'json' };
+  } catch {
+    // not JSON
+  }
+
+  // XML / HTML
+  if (body.trimStart().startsWith('<')) {
+    return {
+      formatted: body
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;'),
+      language: 'xml',
+    };
+  }
+
+  return { formatted: body, language: 'text' };
+}
+
+function getStatusText(code: number | null): string {
+  if (!code) return 'Error';
+  const texts: Record<number, string> = {
+    200: 'OK', 201: 'Created', 204: 'No Content',
+    301: 'Moved Permanently', 302: 'Found', 304: 'Not Modified',
+    400: 'Bad Request', 401: 'Unauthorized', 403: 'Forbidden',
+    404: 'Not Found', 405: 'Method Not Allowed', 409: 'Conflict',
+    422: 'Unprocessable Entity', 429: 'Too Many Requests',
+    500: 'Internal Server Error', 502: 'Bad Gateway',
+    503: 'Service Unavailable', 504: 'Gateway Timeout',
+  };
+  return texts[code] || `Status ${code}`;
+}
+
+export default function ResponseViewer({ response }: ResponseViewerProps) {
+  const [activeTab, setActiveTab] = useState<ResponseTab>('body');
+  const [copied, setCopied] = useState(false);
+  const [wordWrap, setWordWrap] = useState(true);
+
+  const highlighted = useMemo(() => {
+    if (!response.response_body) return null;
+    return formatAndHighlight(response.response_body);
+  }, [response.response_body]);
+
+  const headerCount = Object.keys(response.response_headers).length;
+
+  const copyBody = () => {
+    if (response.response_body) {
+      navigator.clipboard.writeText(response.response_body);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const downloadBody = () => {
+    if (!response.response_body) return;
+    const ext = highlighted?.language === 'json' ? 'json' : highlighted?.language === 'xml' ? 'xml' : 'txt';
+    const blob = new Blob([response.response_body], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `response.${ext}`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const statusColor = !response.status_code
+    ? 'text-red-500'
+    : response.status_code < 300
+      ? 'text-emerald-500'
+      : response.status_code < 400
+        ? 'text-blue-500'
+        : response.status_code < 500
+          ? 'text-amber-500'
+          : 'text-red-500';
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Status bar */}
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-surface-100 dark:border-surface-700/50 bg-surface-50/50 dark:bg-surface-900/30">
+        <div className="flex items-center gap-3">
+          {response.success ? (
+            <CheckCircle className="w-4 h-4 text-emerald-500" />
+          ) : (
+            <XCircle className="w-4 h-4 text-red-500" />
+          )}
+          <span className={cn('text-sm font-bold tabular-nums', statusColor)}>
+            {response.status_code || 'ERR'}
+          </span>
+          <span className="text-xs text-surface-400">
+            {getStatusText(response.status_code)}
+          </span>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {/* Badges */}
+          <span className="px-2 py-0.5 rounded-md bg-surface-100 dark:bg-surface-800 text-[10px] font-medium text-surface-500 tabular-nums">
+            {formatDuration(response.response_time * 1000)}
+          </span>
+          <span className="px-2 py-0.5 rounded-md bg-surface-100 dark:bg-surface-800 text-[10px] font-medium text-surface-500 tabular-nums">
+            {formatBytes(response.response_size)}
+          </span>
+          {response.retry_count > 0 && (
+            <span className="px-2 py-0.5 rounded-md bg-amber-50 dark:bg-amber-900/20 text-[10px] font-medium text-amber-600 dark:text-amber-400 tabular-nums">
+              {response.retry_count} retries
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Error banner */}
+      {response.error && (
+        <div className="px-4 py-2.5 bg-red-50 dark:bg-red-900/10 border-b border-red-200 dark:border-red-800/30">
+          <p className="text-xs font-medium text-red-700 dark:text-red-400">{response.error}</p>
+          {response.error_type && (
+            <p className="text-[10px] text-red-500 mt-0.5">Type: {response.error_type}</p>
+          )}
+        </div>
+      )}
+
+      {/* Response tabs */}
+      <div className="flex items-center justify-between border-b border-surface-100 dark:border-surface-700/50">
+        <div className="flex">
+          <button
+            onClick={() => setActiveTab('body')}
+            className={cn(
+              'px-4 py-2.5 text-xs font-medium transition-colors relative',
+              activeTab === 'body'
+                ? 'text-brand-600 dark:text-brand-400'
+                : 'text-surface-500 hover:text-surface-700 dark:hover:text-surface-300'
+            )}
+          >
+            <div className="flex items-center gap-1.5">
+              <FileJson className="w-3 h-3" />
+              Body
+            </div>
+            {activeTab === 'body' && (
+              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-brand-600 dark:bg-brand-400" />
+            )}
+          </button>
+          <button
+            onClick={() => setActiveTab('headers')}
+            className={cn(
+              'px-4 py-2.5 text-xs font-medium transition-colors relative',
+              activeTab === 'headers'
+                ? 'text-brand-600 dark:text-brand-400'
+                : 'text-surface-500 hover:text-surface-700 dark:hover:text-surface-300'
+            )}
+          >
+            <div className="flex items-center gap-1.5">
+              <Code2 className="w-3 h-3" />
+              Headers
+              {headerCount > 0 && (
+                <span className="text-[10px] font-bold text-surface-400">({headerCount})</span>
+              )}
+            </div>
+            {activeTab === 'headers' && (
+              <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-brand-600 dark:bg-brand-400" />
+            )}
+          </button>
+        </div>
+
+        {/* Actions */}
+        {activeTab === 'body' && response.response_body && (
+          <div className="flex items-center gap-1 pr-2">
+            <button
+              onClick={() => setWordWrap(!wordWrap)}
+              className={cn(
+                'p-1.5 rounded-lg transition-colors',
+                wordWrap ? 'text-brand-500 bg-brand-50 dark:bg-brand-900/20' : 'text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800'
+              )}
+              title="Toggle word wrap"
+            >
+              <WrapText className="w-3.5 h-3.5" />
+            </button>
+            <button onClick={copyBody} className="p-1.5 rounded-lg text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors" title="Copy response">
+              {copied ? <Check className="w-3.5 h-3.5 text-emerald-500" /> : <Copy className="w-3.5 h-3.5" />}
+            </button>
+            <button onClick={downloadBody} className="p-1.5 rounded-lg text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800 transition-colors" title="Download response">
+              <Download className="w-3.5 h-3.5" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Tab content */}
+      <div className="flex-1 overflow-auto">
+        {activeTab === 'body' && (
+          response.response_body ? (
+            <pre
+              className={cn(
+                'p-4 text-xs font-mono leading-relaxed response-highlight',
+                wordWrap ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'
+              )}
+              dangerouslySetInnerHTML={{ __html: highlighted?.formatted || '' }}
+            />
+          ) : (
+            <div className="flex items-center justify-center py-12 text-xs text-surface-400">
+              No response body
+            </div>
+          )
+        )}
+
+        {activeTab === 'headers' && (
+          headerCount > 0 ? (
+            <div className="divide-y divide-surface-100 dark:divide-surface-800/50">
+              {Object.entries(response.response_headers).map(([key, value]) => (
+                <div key={key} className="flex items-start gap-4 px-4 py-2.5 text-xs hover:bg-surface-50 dark:hover:bg-surface-800/30">
+                  <span className="font-medium text-surface-600 dark:text-surface-300 flex-shrink-0 min-w-[140px]">{key}</span>
+                  <span className="font-mono text-surface-500 dark:text-surface-400 break-all">{value}</span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex items-center justify-center py-12 text-xs text-surface-400">
+              No response headers
+            </div>
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react';
 import { useAppStore } from '../store/useAppStore';
 import { cn } from '../lib/utils';
+import CollectionsSidebar from './CollectionsSidebar';
 
 const navItems = [
   { to: '/', icon: LayoutDashboard, label: 'Dashboard', section: 'main' },
@@ -96,11 +97,16 @@ export default function Sidebar() {
             ))}
           </nav>
 
+          {/* Collections */}
+          <div className="px-3 py-3 border-t border-surface-100 dark:border-surface-800 overflow-y-auto max-h-[40vh]">
+            <CollectionsSidebar />
+          </div>
+
           {/* Footer */}
           <div className="p-3 border-t border-surface-100 dark:border-surface-800">
             <div className="px-3 py-2">
               <p className="text-[11px] font-medium text-surface-400 dark:text-surface-600">
-                API-Watch v1.0
+                API-Watch v2.0
               </p>
             </div>
           </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -196,3 +196,31 @@
     @apply animate-fade-in;
   }
 }
+
+/* Response syntax highlighting */
+.response-highlight {
+  @apply text-surface-200;
+}
+.response-highlight .json-string {
+  @apply text-emerald-400;
+}
+.response-highlight .json-number {
+  @apply text-amber-400;
+}
+.response-highlight .json-keyword {
+  @apply text-purple-400;
+}
+
+/* Light mode overrides */
+:root:not(.dark) .response-highlight {
+  @apply text-surface-800;
+}
+:root:not(.dark) .response-highlight .json-string {
+  @apply text-emerald-700;
+}
+:root:not(.dark) .response-highlight .json-number {
+  @apply text-amber-700;
+}
+:root:not(.dark) .response-highlight .json-keyword {
+  @apply text-purple-700;
+}

--- a/frontend/src/pages/SingleRequest.tsx
+++ b/frontend/src/pages/SingleRequest.tsx
@@ -1,11 +1,21 @@
-import { useState } from 'react';
-import { Send, Loader2, CheckCircle, XCircle, Copy, Check, Code2, FileJson } from 'lucide-react';
-import type { RequestConfig, RequestResult } from '../types';
-import { useAppStore } from '../store/useAppStore';
-import { cn, formatDuration, formatBytes } from '../lib/utils';
+import { useCallback, useState } from 'react';
+import {
+  Send,
+  Loader2,
+  Plus,
+  X,
+  Copy,
+} from 'lucide-react';
+import { cn } from '../lib/utils';
 import apiClient from '../lib/api';
+import { useRequestStore } from '../store/useRequestStore';
+import type { HttpMethod, KeyValuePair, TabResponse, BodyType } from '../store/useRequestStore';
+import KeyValueEditor from '../components/KeyValueEditor';
+import BodyEditor from '../components/BodyEditor';
+import ResponseViewer from '../components/ResponseViewer';
+import { useAppStore } from '../store/useAppStore';
 
-const HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] as const;
+const HTTP_METHODS: HttpMethod[] = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS'];
 
 const methodStyles: Record<string, string> = {
   GET: 'bg-emerald-600 text-white',
@@ -13,46 +23,122 @@ const methodStyles: Record<string, string> = {
   PUT: 'bg-amber-600 text-white',
   DELETE: 'bg-red-600 text-white',
   PATCH: 'bg-purple-600 text-white',
+  HEAD: 'bg-teal-600 text-white',
+  OPTIONS: 'bg-gray-600 text-white',
 };
 
-type Tab = 'headers' | 'params' | 'body';
+const methodDotColors: Record<string, string> = {
+  GET: 'bg-emerald-500',
+  POST: 'bg-blue-500',
+  PUT: 'bg-amber-500',
+  DELETE: 'bg-red-500',
+  PATCH: 'bg-purple-500',
+  HEAD: 'bg-teal-500',
+  OPTIONS: 'bg-gray-500',
+};
+
+type RequestPanel = 'params' | 'headers' | 'body';
+
+function deriveTabName(url: string, currentName: string): string {
+  if (currentName && currentName !== 'New Request' && currentName !== 'Untitled') {
+    return currentName;
+  }
+  if (!url) return 'Untitled';
+  try {
+    const u = new URL(url);
+    const path = u.pathname === '/' ? u.hostname : u.pathname;
+    return path.length > 25 ? path.slice(0, 25) : path;
+  } catch {
+    return url.length > 25 ? url.slice(0, 25) : url;
+  }
+}
 
 export default function SingleRequest() {
+  const {
+    tabs,
+    activeTabId,
+    addTab,
+    removeTab,
+    setActiveTab,
+    updateTab,
+    duplicateTab,
+    setResponse,
+    setLoading,
+    getActiveTab,
+  } = useRequestStore();
+
   const { addToHistory } = useAppStore();
-  const [config, setConfig] = useState<RequestConfig>({
-    method: 'GET',
-    url: 'https://jsonplaceholder.typicode.com/posts/1',
-    headers: {},
-    params: {},
-    body: null,
-    timeout: 10,
-  });
+  const [activePanel, setActivePanel] = useState<RequestPanel>('params');
+  const [contextMenuTab, setContextMenuTab] = useState<string | null>(null);
 
-  const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<RequestResult | null>(null);
-  const [headersText, setHeadersText] = useState('');
-  const [paramsText, setParamsText] = useState('');
-  const [bodyText, setBodyText] = useState('');
-  const [activeTab, setActiveTab] = useState<Tab>('headers');
-  const [copied, setCopied] = useState(false);
+  const tab = getActiveTab();
 
-  const executeRequest = async () => {
-    setLoading(true);
-    setResult(null);
+  const executeRequest = useCallback(async () => {
+    if (!tab.url) return;
+    const tabId = tab.id;
+    setLoading(tabId, true);
 
     try {
-      const headers = headersText ? JSON.parse(headersText) : {};
-      const params = paramsText ? JSON.parse(paramsText) : {};
-      const body = bodyText ? JSON.parse(bodyText) : null;
-      const requestData = { ...config, headers, params, body };
+      const headers: Record<string, string> = {};
+      tab.headers
+        .filter((h) => h.enabled && h.key)
+        .forEach((h) => { headers[h.key] = h.value; });
 
-      const response = await apiClient.post('/api/execute-request', requestData);
-      const requestResult: RequestResult = response.data;
-      setResult(requestResult);
-      addToHistory(requestResult);
+      const params: Record<string, string> = {};
+      tab.params
+        .filter((p) => p.enabled && p.key)
+        .forEach((p) => { params[p.key] = p.value; });
+
+      let body: any = null;
+      if (tab.method !== 'GET' && tab.method !== 'HEAD') {
+        if (tab.bodyType === 'json') {
+          try { body = JSON.parse(tab.bodyRaw); } catch { body = tab.bodyRaw; }
+          if (!headers['Content-Type']) headers['Content-Type'] = 'application/json';
+        } else if (tab.bodyType === 'text' || tab.bodyType === 'xml') {
+          body = tab.bodyRaw;
+          if (tab.bodyType === 'xml' && !headers['Content-Type']) {
+            headers['Content-Type'] = 'application/xml';
+          }
+        } else if (tab.bodyType === 'form-data' || tab.bodyType === 'x-www-form-urlencoded') {
+          const formObj: Record<string, string> = {};
+          tab.bodyFormData
+            .filter((f) => f.enabled && f.key)
+            .forEach((f) => { formObj[f.key] = f.value; });
+          body = formObj;
+          if (tab.bodyType === 'x-www-form-urlencoded' && !headers['Content-Type']) {
+            headers['Content-Type'] = 'application/x-www-form-urlencoded';
+          }
+        }
+      }
+
+      const res = await apiClient.post('/api/execute-request', {
+        method: tab.method,
+        url: tab.url,
+        headers,
+        params,
+        body,
+        timeout: tab.timeout,
+      });
+      const result = res.data;
+
+      const tabResponse: TabResponse = {
+        success: result.success,
+        status_code: result.status_code,
+        response_time: result.response_time,
+        response_size: result.response_size,
+        response_body: result.response_body,
+        response_headers: result.response_headers || {},
+        error: result.error,
+        error_type: result.error_type,
+        retry_count: result.retry_count || 0,
+        timestamp: result.timestamp || new Date().toISOString(),
+      };
+
+      setResponse(tabId, tabResponse);
+      addToHistory(result);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Request failed';
-      const errorResult: RequestResult = {
+      setResponse(tab.id, {
         success: false,
         status_code: null,
         response_time: 0,
@@ -63,259 +149,216 @@ export default function SingleRequest() {
         error_type: 'CLIENT_ERROR',
         retry_count: 0,
         timestamp: new Date().toISOString(),
-        request_method: config.method,
-        request_url: config.url,
-      };
-      setResult(errorResult);
-    } finally {
-      setLoading(false);
+      });
     }
-  };
+  }, [tab, setLoading, setResponse, addToHistory]);
 
-  const copyResponse = () => {
-    if (result?.response_body) {
-      navigator.clipboard.writeText(result.response_body);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    }
-  };
+  const update = (updates: Partial<typeof tab>) => updateTab(tab.id, updates);
 
-  const formatResponseBody = (body: string): string => {
-    try {
-      return JSON.stringify(JSON.parse(body), null, 2);
-    } catch {
-      return body;
-    }
-  };
+  const enabledParamsCount = tab.params.filter((p) => p.enabled && p.key).length;
+  const enabledHeadersCount = tab.headers.filter((h) => h.enabled && h.key).length;
 
-  const tabs: { id: Tab; label: string; show: boolean }[] = [
-    { id: 'headers', label: 'Headers', show: true },
-    { id: 'params', label: 'Params', show: true },
-    { id: 'body', label: 'Body', show: config.method !== 'GET' },
+  const panels: { id: RequestPanel; label: string; count?: number }[] = [
+    { id: 'params', label: 'Params', count: enabledParamsCount },
+    { id: 'headers', label: 'Headers', count: enabledHeadersCount },
+    { id: 'body', label: 'Body' },
   ];
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div>
-        <h1 className="section-title">Request Builder</h1>
-        <p className="section-subtitle">Execute and debug individual API requests</p>
+    <div className="flex flex-col h-[calc(100vh-7rem)]">
+      {/* Tab Bar */}
+      <div className="flex items-center gap-0.5 px-1 py-1 bg-surface-100 dark:bg-surface-900 rounded-xl mb-3 overflow-x-auto">
+        {tabs.map((t) => (
+          <div
+            key={t.id}
+            className="relative group"
+            onContextMenu={(e) => {
+              e.preventDefault();
+              setContextMenuTab(t.id === contextMenuTab ? null : t.id);
+            }}
+          >
+            <button
+              onClick={() => setActiveTab(t.id)}
+              className={cn(
+                'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-all whitespace-nowrap',
+                t.id === activeTabId
+                  ? 'bg-white dark:bg-surface-800 text-surface-900 dark:text-white shadow-sm'
+                  : 'text-surface-500 hover:text-surface-700 dark:hover:text-surface-300 hover:bg-surface-200/50 dark:hover:bg-surface-800/50'
+              )}
+            >
+              <div className={cn('w-1.5 h-1.5 rounded-full flex-shrink-0', methodDotColors[t.method] || 'bg-gray-400')} />
+              <span className="max-w-[120px] truncate">{t.name || 'Untitled'}</span>
+              {t.isDirty && <span className="w-1.5 h-1.5 rounded-full bg-amber-400 flex-shrink-0" />}
+              <button
+                onClick={(e) => { e.stopPropagation(); removeTab(t.id); }}
+                className="p-0.5 rounded opacity-0 group-hover:opacity-100 hover:bg-surface-200 dark:hover:bg-surface-700 transition-opacity"
+              >
+                <X className="w-2.5 h-2.5" />
+              </button>
+            </button>
+
+            {contextMenuTab === t.id && (
+              <>
+                <div className="fixed inset-0 z-40" onClick={() => setContextMenuTab(null)} />
+                <div className="absolute top-full left-0 mt-1 z-50 bg-white dark:bg-surface-800 border border-surface-200 dark:border-surface-700 rounded-xl shadow-lg py-1 min-w-[140px]">
+                  <button
+                    onClick={() => { duplicateTab(t.id); setContextMenuTab(null); }}
+                    className="w-full px-3 py-1.5 text-left text-xs text-surface-600 dark:text-surface-300 hover:bg-surface-50 dark:hover:bg-surface-700/50 flex items-center gap-2"
+                  >
+                    <Copy className="w-3 h-3" /> Duplicate
+                  </button>
+                  <button
+                    onClick={() => { removeTab(t.id); setContextMenuTab(null); }}
+                    className="w-full px-3 py-1.5 text-left text-xs text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/10 flex items-center gap-2"
+                  >
+                    <X className="w-3 h-3" /> Close
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        ))}
+
+        <button
+          onClick={() => addTab()}
+          className="p-1.5 rounded-lg text-surface-400 hover:text-surface-600 hover:bg-surface-200/50 dark:hover:bg-surface-800/50 transition-colors flex-shrink-0"
+          title="New tab"
+        >
+          <Plus className="w-3.5 h-3.5" />
+        </button>
       </div>
 
-      <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
-        {/* Request Builder */}
-        <div className="space-y-4">
-          {/* URL Bar */}
-          <div className="card !p-4">
-            <div className="flex gap-2">
-              <select
-                value={config.method}
-                onChange={(e) => setConfig({ ...config, method: e.target.value as RequestConfig['method'] })}
+      {/* URL Bar */}
+      <div className="card !p-3 mb-3">
+        <div className="flex gap-2">
+          <select
+            value={tab.method}
+            onChange={(e) => update({ method: e.target.value as HttpMethod })}
+            className={cn(
+              'px-3 py-2.5 rounded-xl text-xs font-bold tracking-wide appearance-none cursor-pointer min-w-[90px]',
+              'focus:outline-none focus:ring-2 focus:ring-brand-500/20 transition-colors',
+              methodStyles[tab.method]
+            )}
+          >
+            {HTTP_METHODS.map((m) => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
+
+          <input
+            type="text"
+            value={tab.url}
+            onChange={(e) => update({ url: e.target.value, name: deriveTabName(e.target.value, tab.name) })}
+            onKeyDown={(e) => { if (e.key === 'Enter') executeRequest(); }}
+            placeholder="https://api.example.com/endpoint"
+            className="input flex-1 font-mono text-sm"
+          />
+
+          <button
+            onClick={executeRequest}
+            disabled={tab.isLoading || !tab.url}
+            className="btn-primary !px-5"
+          >
+            {tab.isLoading ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Send className="w-4 h-4" />
+            )}
+            <span className="hidden sm:inline">Send</span>
+          </button>
+        </div>
+      </div>
+
+      {/* Request / Response split */}
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-3 flex-1 min-h-0">
+        {/* Left: Request config */}
+        <div className="card !p-0 overflow-hidden flex flex-col min-h-[300px]">
+          <div className="flex border-b border-surface-100 dark:border-surface-700/50">
+            {panels.map((p) => (
+              <button
+                key={p.id}
+                onClick={() => setActivePanel(p.id)}
                 className={cn(
-                  'px-3 py-2.5 rounded-xl text-xs font-bold tracking-wide appearance-none cursor-pointer',
-                  'focus:outline-none focus:ring-2 focus:ring-brand-500/20',
-                  'transition-colors',
-                  methodStyles[config.method]
+                  'px-4 py-2.5 text-xs font-medium transition-colors relative',
+                  activePanel === p.id
+                    ? 'text-brand-600 dark:text-brand-400'
+                    : 'text-surface-500 hover:text-surface-700 dark:hover:text-surface-300'
                 )}
               >
-                {HTTP_METHODS.map((method) => (
-                  <option key={method} value={method}>{method}</option>
-                ))}
-              </select>
-
-              <input
-                type="text"
-                value={config.url}
-                onChange={(e) => setConfig({ ...config, url: e.target.value })}
-                placeholder="https://api.example.com/endpoint"
-                className="input flex-1 font-mono text-sm"
-              />
-
-              <button
-                onClick={executeRequest}
-                disabled={loading || !config.url}
-                className="btn-primary !px-5"
-              >
-                {loading ? (
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                ) : (
-                  <Send className="w-4 h-4" />
+                {p.label}
+                {p.count !== undefined && p.count > 0 && (
+                  <span className="ml-1 text-[10px] font-bold text-brand-500">({p.count})</span>
+                )}
+                {activePanel === p.id && (
+                  <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-brand-600 dark:bg-brand-400" />
                 )}
               </button>
+            ))}
+
+            <div className="ml-auto flex items-center gap-1.5 pr-3">
+              <span className="text-[10px] text-surface-400">Timeout</span>
+              <input
+                type="number"
+                value={tab.timeout}
+                onChange={(e) => update({ timeout: parseInt(e.target.value) || 10 })}
+                className="input !w-14 !py-1 text-center text-xs"
+                min={1}
+                max={120}
+              />
+              <span className="text-[10px] text-surface-400">s</span>
             </div>
           </div>
 
-          {/* Tabs + Content */}
-          <div className="card !p-0 overflow-hidden">
-            {/* Tab bar */}
-            <div className="flex border-b border-surface-100 dark:border-surface-700/50">
-              {tabs.filter(t => t.show).map((tab) => (
-                <button
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  className={cn(
-                    'px-4 py-3 text-xs font-medium transition-colors relative',
-                    activeTab === tab.id
-                      ? 'text-brand-600 dark:text-brand-400'
-                      : 'text-surface-500 hover:text-surface-700 dark:hover:text-surface-300'
-                  )}
-                >
-                  {tab.label}
-                  {activeTab === tab.id && (
-                    <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-brand-600 dark:bg-brand-400" />
-                  )}
-                </button>
-              ))}
-            </div>
-
-            {/* Tab Content */}
-            <div className="p-4">
-              {activeTab === 'headers' && (
-                <textarea
-                  value={headersText}
-                  onChange={(e) => setHeadersText(e.target.value)}
-                  placeholder='{"Content-Type": "application/json", "Authorization": "Bearer ..."}'
-                  className="input font-mono text-xs !rounded-xl"
-                  rows={5}
-                />
-              )}
-              {activeTab === 'params' && (
-                <textarea
-                  value={paramsText}
-                  onChange={(e) => setParamsText(e.target.value)}
-                  placeholder='{"page": "1", "limit": "10"}'
-                  className="input font-mono text-xs !rounded-xl"
-                  rows={5}
-                />
-              )}
-              {activeTab === 'body' && config.method !== 'GET' && (
-                <textarea
-                  value={bodyText}
-                  onChange={(e) => setBodyText(e.target.value)}
-                  placeholder='{"key": "value"}'
-                  className="input font-mono text-xs !rounded-xl"
-                  rows={8}
-                />
-              )}
-            </div>
-
-            {/* Timeout */}
-            <div className="px-4 pb-4 flex items-center gap-3">
-              <label className="text-xs font-medium text-surface-500">Timeout</label>
-              <input
-                type="number"
-                value={config.timeout}
-                onChange={(e) => setConfig({ ...config, timeout: parseInt(e.target.value) || 10 })}
-                className="input !w-20 text-center text-xs"
-                min="1"
-                max="120"
+          <div className="flex-1 overflow-auto p-4">
+            {activePanel === 'params' && (
+              <KeyValueEditor
+                pairs={tab.params}
+                onChange={(pairs: KeyValuePair[]) => update({ params: pairs })}
+                keyPlaceholder="Parameter"
+                valuePlaceholder="Value"
               />
-              <span className="text-xs text-surface-400">seconds</span>
-            </div>
+            )}
+
+            {activePanel === 'headers' && (
+              <KeyValueEditor
+                pairs={tab.headers}
+                onChange={(pairs: KeyValuePair[]) => update({ headers: pairs })}
+                keyPlaceholder="Header"
+                valuePlaceholder="Value"
+              />
+            )}
+
+            {activePanel === 'body' && (
+              <BodyEditor
+                method={tab.method}
+                bodyType={tab.bodyType}
+                bodyRaw={tab.bodyRaw}
+                bodyFormData={tab.bodyFormData}
+                onBodyTypeChange={(bt: BodyType) => update({ bodyType: bt })}
+                onBodyRawChange={(raw: string) => update({ bodyRaw: raw })}
+                onBodyFormDataChange={(fd: KeyValuePair[]) => update({ bodyFormData: fd })}
+              />
+            )}
           </div>
         </div>
 
-        {/* Response Panel */}
-        <div className="space-y-4">
-          {result ? (
-            <>
-              {/* Status Card */}
-              <div className={cn(
-                'card !p-4 border-l-4',
-                result.success ? 'border-l-emerald-500' : 'border-l-red-500'
-              )}>
-                <div className="flex items-center justify-between mb-3">
-                  <div className="flex items-center gap-2.5">
-                    {result.success ? (
-                      <CheckCircle className="w-5 h-5 text-emerald-500" />
-                    ) : (
-                      <XCircle className="w-5 h-5 text-red-500" />
-                    )}
-                    <span className="text-sm font-semibold text-surface-900 dark:text-white">
-                      {result.success ? 'Request Successful' : 'Request Failed'}
-                    </span>
-                  </div>
-                  <span className={cn(
-                    'text-lg font-bold tabular-nums',
-                    result.success ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
-                  )}>
-                    {result.status_code || 'ERR'}
-                  </span>
-                </div>
-
-                <div className="grid grid-cols-3 gap-3">
-                  {[
-                    { label: 'Time', value: formatDuration(result.response_time * 1000) },
-                    { label: 'Size', value: formatBytes(result.response_size) },
-                    { label: 'Retries', value: String(result.retry_count) },
-                  ].map((item) => (
-                    <div key={item.label} className="bg-surface-50 dark:bg-surface-900/50 rounded-xl px-3 py-2 text-center">
-                      <p className="text-[10px] font-medium text-surface-400 uppercase tracking-wide">{item.label}</p>
-                      <p className="text-sm font-semibold text-surface-900 dark:text-white tabular-nums mt-0.5">{item.value}</p>
-                    </div>
-                  ))}
-                </div>
-
-                {result.error && (
-                  <div className="mt-3 p-3 bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800/30 rounded-xl">
-                    <p className="text-xs font-medium text-red-700 dark:text-red-400">{result.error}</p>
-                    {result.error_type && (
-                      <p className="text-[10px] text-red-500 dark:text-red-500 mt-1">Type: {result.error_type}</p>
-                    )}
-                  </div>
-                )}
-              </div>
-
-              {/* Response Body */}
-              {result.response_body && (
-                <div className="card !p-0 overflow-hidden">
-                  <div className="flex items-center justify-between px-4 py-3 border-b border-surface-100 dark:border-surface-700/50">
-                    <div className="flex items-center gap-2">
-                      <FileJson className="w-3.5 h-3.5 text-surface-400" />
-                      <span className="text-xs font-medium text-surface-600 dark:text-surface-400">Response Body</span>
-                    </div>
-                    <button onClick={copyResponse} className="btn-ghost !p-1.5 !rounded-lg">
-                      {copied ? (
-                        <Check className="w-3.5 h-3.5 text-emerald-500" />
-                      ) : (
-                        <Copy className="w-3.5 h-3.5" />
-                      )}
-                    </button>
-                  </div>
-                  <pre className="code-block !rounded-none !border-0 max-h-80 overflow-y-auto text-xs leading-relaxed">
-                    {formatResponseBody(result.response_body)}
-                  </pre>
-                </div>
-              )}
-
-              {/* Response Headers */}
-              {Object.keys(result.response_headers).length > 0 && (
-                <div className="card !p-0 overflow-hidden">
-                  <div className="flex items-center gap-2 px-4 py-3 border-b border-surface-100 dark:border-surface-700/50">
-                    <Code2 className="w-3.5 h-3.5 text-surface-400" />
-                    <span className="text-xs font-medium text-surface-600 dark:text-surface-400">
-                      Response Headers ({Object.keys(result.response_headers).length})
-                    </span>
-                  </div>
-                  <div className="divide-y divide-surface-100 dark:divide-surface-800/50">
-                    {Object.entries(result.response_headers).map(([key, value]) => (
-                      <div key={key} className="flex items-start justify-between gap-4 px-4 py-2.5 text-xs">
-                        <span className="font-medium text-surface-600 dark:text-surface-300 flex-shrink-0">{key}</span>
-                        <span className="font-mono text-surface-500 dark:text-surface-400 text-right truncate">{value}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </>
+        {/* Right: Response */}
+        <div className="card !p-0 overflow-hidden flex flex-col min-h-[300px]">
+          {tab.isLoading ? (
+            <div className="flex-1 flex flex-col items-center justify-center gap-3">
+              <Loader2 className="w-8 h-8 text-brand-500 animate-spin" />
+              <p className="text-xs text-surface-400">Sending request...</p>
+            </div>
+          ) : tab.response ? (
+            <ResponseViewer response={tab.response} />
           ) : (
-            <div className="card empty-state py-20">
-              <div className="w-12 h-12 rounded-2xl bg-surface-100 dark:bg-surface-800 flex items-center justify-center mb-4">
+            <div className="flex-1 flex flex-col items-center justify-center gap-3">
+              <div className="w-12 h-12 rounded-2xl bg-surface-100 dark:bg-surface-800 flex items-center justify-center">
                 <Send className="w-5 h-5 text-surface-400" />
               </div>
-              <h3 className="empty-state-title">Ready to send</h3>
-              <p className="empty-state-desc">
-                Configure your request and hit send to see the response
+              <p className="text-sm font-medium text-surface-500">Ready to send</p>
+              <p className="text-xs text-surface-400">
+                Enter a URL and hit Enter or click Send
               </p>
             </div>
           )}

--- a/frontend/src/store/useRequestStore.ts
+++ b/frontend/src/store/useRequestStore.ts
@@ -1,0 +1,205 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'HEAD' | 'OPTIONS';
+
+export interface KeyValuePair {
+  id: string;
+  key: string;
+  value: string;
+  enabled: boolean;
+}
+
+export type BodyType = 'none' | 'json' | 'text' | 'xml' | 'form-data' | 'x-www-form-urlencoded';
+
+export interface RequestTab {
+  id: string;
+  name: string;
+  method: HttpMethod;
+  url: string;
+  headers: KeyValuePair[];
+  params: KeyValuePair[];
+  bodyType: BodyType;
+  bodyRaw: string;               // raw body text (json / xml / text)
+  bodyFormData: KeyValuePair[];   // form-data pairs
+  timeout: number;
+  isDirty: boolean;
+  // response state (kept per-tab so switching tabs preserves results)
+  response: TabResponse | null;
+  isLoading: boolean;
+  // optional link back to a saved request
+  savedRequestId?: string;
+  collectionId?: string;
+}
+
+export interface TabResponse {
+  success: boolean;
+  status_code: number | null;
+  response_time: number;
+  response_size: number;
+  response_body: string | null;
+  response_headers: Record<string, string>;
+  error: string | null;
+  error_type: string | null;
+  retry_count: number;
+  timestamp: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+let _counter = 0;
+export function uid(): string {
+  return `${Date.now()}-${++_counter}`;
+}
+
+export function emptyKV(): KeyValuePair {
+  return { id: uid(), key: '', value: '', enabled: true };
+}
+
+function newTab(partial?: Partial<RequestTab>): RequestTab {
+  return {
+    id: uid(),
+    name: 'New Request',
+    method: 'GET',
+    url: '',
+    headers: [emptyKV()],
+    params: [emptyKV()],
+    bodyType: 'none',
+    bodyRaw: '',
+    bodyFormData: [emptyKV()],
+    timeout: 10,
+    isDirty: false,
+    response: null,
+    isLoading: false,
+    ...partial,
+  };
+}
+
+// ── Store ────────────────────────────────────────────────────────────────────
+
+interface RequestState {
+  tabs: RequestTab[];
+  activeTabId: string;
+
+  // Tab management
+  addTab: (partial?: Partial<RequestTab>) => string;
+  removeTab: (tabId: string) => void;
+  setActiveTab: (tabId: string) => void;
+  updateTab: (tabId: string, updates: Partial<RequestTab>) => void;
+  duplicateTab: (tabId: string) => void;
+  renameTab: (tabId: string, name: string) => void;
+
+  // Convenience
+  getActiveTab: () => RequestTab;
+  setResponse: (tabId: string, response: TabResponse | null) => void;
+  setLoading: (tabId: string, loading: boolean) => void;
+}
+
+export const useRequestStore = create<RequestState>()(
+  persist(
+    (set, get) => {
+      const initialTab = newTab({ name: 'Untitled' });
+
+      return {
+        tabs: [initialTab],
+        activeTabId: initialTab.id,
+
+        addTab: (partial) => {
+          const tab = newTab(partial);
+          set((s) => ({
+            tabs: [...s.tabs, tab],
+            activeTabId: tab.id,
+          }));
+          return tab.id;
+        },
+
+        removeTab: (tabId) => {
+          set((s) => {
+            if (s.tabs.length <= 1) {
+              // Don't close last tab – reset it instead
+              const fresh = newTab({ name: 'Untitled' });
+              return { tabs: [fresh], activeTabId: fresh.id };
+            }
+            const idx = s.tabs.findIndex((t) => t.id === tabId);
+            const remaining = s.tabs.filter((t) => t.id !== tabId);
+            let nextActive = s.activeTabId;
+            if (s.activeTabId === tabId) {
+              // Activate the tab to the left, or the first tab
+              const nextIdx = Math.max(0, idx - 1);
+              nextActive = remaining[nextIdx].id;
+            }
+            return { tabs: remaining, activeTabId: nextActive };
+          });
+        },
+
+        setActiveTab: (tabId) => set({ activeTabId: tabId }),
+
+        updateTab: (tabId, updates) => {
+          set((s) => ({
+            tabs: s.tabs.map((t) =>
+              t.id === tabId ? { ...t, ...updates, isDirty: true } : t
+            ),
+          }));
+        },
+
+        duplicateTab: (tabId) => {
+          const tab = get().tabs.find((t) => t.id === tabId);
+          if (!tab) return;
+          const dup = newTab({
+            ...tab,
+            id: undefined as any, // will be overwritten by newTab
+            name: `${tab.name} (copy)`,
+            response: null,
+            isLoading: false,
+            savedRequestId: undefined,
+            isDirty: false,
+          });
+          set((s) => ({
+            tabs: [...s.tabs, dup],
+            activeTabId: dup.id,
+          }));
+        },
+
+        renameTab: (tabId, name) => {
+          set((s) => ({
+            tabs: s.tabs.map((t) => (t.id === tabId ? { ...t, name } : t)),
+          }));
+        },
+
+        getActiveTab: () => {
+          const s = get();
+          return s.tabs.find((t) => t.id === s.activeTabId) || s.tabs[0];
+        },
+
+        setResponse: (tabId, response) => {
+          set((s) => ({
+            tabs: s.tabs.map((t) =>
+              t.id === tabId ? { ...t, response, isLoading: false } : t
+            ),
+          }));
+        },
+
+        setLoading: (tabId, loading) => {
+          set((s) => ({
+            tabs: s.tabs.map((t) =>
+              t.id === tabId ? { ...t, isLoading: loading } : t
+            ),
+          }));
+        },
+      };
+    },
+    {
+      name: 'api-watch-requests',
+      partialize: (state) => ({
+        tabs: state.tabs.map((t) => ({
+          ...t,
+          isLoading: false,      // never persist loading state
+          response: null,         // don't persist large response bodies
+        })),
+        activeTabId: state.activeTabId,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
… viewer, collections, environments)

- Add useRequestStore with tab management (add/remove/duplicate/rename tabs)
- Add KeyValueEditor component with bulk edit mode and enable/disable toggles
- Add BodyEditor component (json, text, xml, form-data, x-www-form-urlencoded)
- Add ResponseViewer with custom JSON syntax highlighting, copy/download, status bar
- Rewrite SingleRequest page with full tab bar, method dropdown, request/response panels
- Add CollectionsSidebar with tree view, inline create/delete, open-in-tab
- Add EnvironmentSelector with dropdown switcher and editor modal
- Integrate CollectionsSidebar into Sidebar, EnvironmentSelector into Header
- Bump version to v2.0, update tests

## Description
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] 🧪 Tests
- [ ] 🔧 Config / CI

## Phase
<!-- Which implementation phase does this belong to? -->
- [ ] Phase 1: Foundation (DB, Async, Auth)
- [ ] Phase 2: Core UX (Tabs, Collections, Request Builder)
- [ ] Phase 3: Environments & Variables
- [ ] Phase 4: Scripting & Assertions
- [ ] Phase 5: Advanced Features
- [ ] Phase 6: Collaboration & Polish

## Changes
- 

## Testing
- [ ] Backend tests pass (`pytest`)
- [ ] Frontend tests pass (`npm test`)
- [ ] Manual testing done
- [ ] CI/CD pipeline passes

## Screenshots
<!-- If UI changes, add screenshots -->
