### PR TITLE
feat: Phase 3 - Environments & Variables (interpolation, dynamic vars…

### DIFF
--- a/frontend/src/__tests__/interpolate.test.ts
+++ b/frontend/src/__tests__/interpolate.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from 'vitest';
+import {
+  interpolateString,
+  interpolateRecord,
+  interpolateBody,
+  extractVariables,
+  getUnresolvedVariables,
+  hasVariables,
+  previewInterpolation,
+  DYNAMIC_VARIABLE_NAMES,
+} from '../lib/interpolate';
+
+const vars = {
+  BASE_URL: 'https://api.example.com',
+  TOKEN: 'abc123',
+  USER_ID: '42',
+};
+
+describe('interpolateString', () => {
+  it('replaces known variables', () => {
+    expect(interpolateString('{{BASE_URL}}/users/{{USER_ID}}', vars))
+      .toBe('https://api.example.com/users/42');
+  });
+
+  it('leaves unresolved variables unchanged', () => {
+    expect(interpolateString('{{BASE_URL}}/{{UNKNOWN}}', vars))
+      .toBe('https://api.example.com/{{UNKNOWN}}');
+  });
+
+  it('handles empty string', () => {
+    expect(interpolateString('', vars)).toBe('');
+  });
+
+  it('returns input without variables unchanged', () => {
+    expect(interpolateString('https://plain.com', vars)).toBe('https://plain.com');
+  });
+
+  it('handles multiple occurrences of same variable', () => {
+    expect(interpolateString('{{TOKEN}}-{{TOKEN}}', vars)).toBe('abc123-abc123');
+  });
+
+  it('resolves dynamic $timestamp variable', () => {
+    const result = interpolateString('ts={{$timestamp}}', vars);
+    expect(result).toMatch(/^ts=\d+$/);
+  });
+
+  it('resolves dynamic $randomUUID variable', () => {
+    const result = interpolateString('id={{$randomUUID}}', vars);
+    expect(result).not.toContain('{{$randomUUID}}');
+    expect(result.length).toBeGreaterThan(5);
+  });
+
+  it('resolves dynamic $randomEmail variable', () => {
+    const result = interpolateString('email={{$randomEmail}}', vars);
+    expect(result).toContain('@test.example.com');
+  });
+
+  it('resolves dynamic $randomInt variable', () => {
+    const result = interpolateString('n={{$randomInt}}', vars);
+    expect(result).toMatch(/^n=\d+$/);
+  });
+
+  it('handles mix of user vars and dynamic vars', () => {
+    const result = interpolateString('{{BASE_URL}}/{{$randomUUID}}', vars);
+    expect(result).toMatch(/^https:\/\/api\.example\.com\/.+$/);
+    expect(result).not.toContain('{{');
+  });
+});
+
+describe('interpolateRecord', () => {
+  it('interpolates both keys and values', () => {
+    const result = interpolateRecord(
+      { Authorization: 'Bearer {{TOKEN}}', 'X-User': '{{USER_ID}}' },
+      vars
+    );
+    expect(result).toEqual({
+      Authorization: 'Bearer abc123',
+      'X-User': '42',
+    });
+  });
+
+  it('handles empty object', () => {
+    expect(interpolateRecord({}, vars)).toEqual({});
+  });
+});
+
+describe('interpolateBody', () => {
+  it('interpolates string body', () => {
+    expect(interpolateBody('{"token": "{{TOKEN}}"}', vars))
+      .toBe('{"token": "abc123"}');
+  });
+
+  it('interpolates object body', () => {
+    const result = interpolateBody({ user: '{{USER_ID}}', name: 'test' }, vars);
+    expect(result).toEqual({ user: '42', name: 'test' });
+  });
+
+  it('returns null for null body', () => {
+    expect(interpolateBody(null, vars)).toBeNull();
+  });
+
+  it('returns undefined for undefined body', () => {
+    expect(interpolateBody(undefined, vars)).toBeUndefined();
+  });
+});
+
+describe('extractVariables', () => {
+  it('extracts variable names', () => {
+    expect(extractVariables('{{BASE_URL}}/{{USER_ID}}')).toEqual(['BASE_URL', 'USER_ID']);
+  });
+
+  it('deduplicates names', () => {
+    expect(extractVariables('{{A}}-{{A}}')).toEqual(['A']);
+  });
+
+  it('returns empty for no variables', () => {
+    expect(extractVariables('plain text')).toEqual([]);
+  });
+
+  it('extracts dynamic variable names', () => {
+    expect(extractVariables('{{$timestamp}}')).toEqual(['$timestamp']);
+  });
+});
+
+describe('getUnresolvedVariables', () => {
+  it('returns variables not in vars dict', () => {
+    expect(getUnresolvedVariables('{{BASE_URL}}/{{MISSING}}', vars)).toEqual(['MISSING']);
+  });
+
+  it('does NOT flag dynamic variables as unresolved', () => {
+    expect(getUnresolvedVariables('{{$timestamp}}', vars)).toEqual([]);
+  });
+
+  it('returns empty when all resolved', () => {
+    expect(getUnresolvedVariables('{{BASE_URL}}', vars)).toEqual([]);
+  });
+});
+
+describe('hasVariables', () => {
+  it('returns true for strings with variables', () => {
+    expect(hasVariables('{{BASE_URL}}')).toBe(true);
+  });
+
+  it('returns false for plain strings', () => {
+    expect(hasVariables('https://example.com')).toBe(false);
+  });
+
+  it('returns true for dynamic variables', () => {
+    expect(hasVariables('{{$randomUUID}}')).toBe(true);
+  });
+});
+
+describe('previewInterpolation', () => {
+  it('resolves user vars but shows dynamic var placeholders', () => {
+    const result = previewInterpolation('{{BASE_URL}}/{{$randomUUID}}', vars);
+    expect(result).toBe('https://api.example.com/<$randomUUID>');
+  });
+
+  it('leaves unresolved vars as-is', () => {
+    const result = previewInterpolation('{{MISSING}}', vars);
+    expect(result).toBe('{{MISSING}}');
+  });
+});
+
+describe('DYNAMIC_VARIABLE_NAMES', () => {
+  it('contains expected dynamic variables', () => {
+    expect(DYNAMIC_VARIABLE_NAMES).toContain('$randomUUID');
+    expect(DYNAMIC_VARIABLE_NAMES).toContain('$timestamp');
+    expect(DYNAMIC_VARIABLE_NAMES).toContain('$isoTimestamp');
+    expect(DYNAMIC_VARIABLE_NAMES).toContain('$randomEmail');
+    expect(DYNAMIC_VARIABLE_NAMES).toContain('$randomInt');
+    expect(DYNAMIC_VARIABLE_NAMES).toContain('$randomString');
+  });
+});

--- a/frontend/src/components/EnvironmentSelector.tsx
+++ b/frontend/src/components/EnvironmentSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Globe,
   ChevronDown,
@@ -9,70 +9,43 @@ import {
   Pencil,
 } from 'lucide-react';
 import { cn } from '../lib/utils';
-import apiClient from '../lib/api';
-
-interface Environment {
-  id: string;
-  name: string;
-  variables: Record<string, string>;
-  is_active: boolean;
-}
+import { useEnvironmentStore } from '../store/useEnvironmentStore';
+import type { EnvironmentEntry } from '../store/useEnvironmentStore';
 
 export default function EnvironmentSelector() {
-  const [environments, setEnvironments] = useState<Environment[]>([]);
-  const [activeEnv, setActiveEnv] = useState<Environment | null>(null);
+  const {
+    environments,
+    activeEnv,
+    fetchEnvironments,
+    activate,
+    deactivate,
+    createEnvironment,
+    updateEnvironment,
+    deleteEnvironment,
+  } = useEnvironmentStore();
+
   const [isOpen, setIsOpen] = useState(false);
   const [showEditor, setShowEditor] = useState(false);
-  const [editorEnv, setEditorEnv] = useState<Environment | null>(null);
+  const [editorEnv, setEditorEnv] = useState<EnvironmentEntry | null>(null);
   const [newName, setNewName] = useState('');
   const [newVars, setNewVars] = useState('');
   const [saving, setSaving] = useState(false);
-
-  const fetchEnvironments = useCallback(async () => {
-    try {
-      const res = await apiClient.get('/api/v1/environments');
-      setEnvironments(res.data);
-      const active = res.data.find((e: Environment) => e.is_active);
-      setActiveEnv(active || null);
-    } catch {
-      setEnvironments([]);
-    }
-  }, []);
 
   useEffect(() => {
     fetchEnvironments();
   }, [fetchEnvironments]);
 
-  const selectEnvironment = async (env: Environment) => {
-    try {
-      await apiClient.put(`/api/v1/environments/${env.id}`, {
-        name: env.name,
-        variables: env.variables,
-        is_active: true,
-      });
-      setIsOpen(false);
-      fetchEnvironments();
-    } catch {
-      // ignore
-    }
+  const selectEnvironment = async (env: EnvironmentEntry) => {
+    setIsOpen(false);
+    await activate(env);
   };
 
-  const deactivateAll = async () => {
-    if (!activeEnv) return;
-    try {
-      await apiClient.put(`/api/v1/environments/${activeEnv.id}`, {
-        name: activeEnv.name,
-        variables: activeEnv.variables,
-        is_active: false,
-      });
-      setIsOpen(false);
-      fetchEnvironments();
-    } catch {
-      // ignore
-    }
+  const handleDeactivate = async () => {
+    setIsOpen(false);
+    await deactivate();
   };
 
-  const openEditor = (env?: Environment) => {
+  const openEditor = (env?: EnvironmentEntry) => {
     if (env) {
       setEditorEnv(env);
       setNewName(env.name);
@@ -107,19 +80,15 @@ export default function EnvironmentSelector() {
     try {
       const variables = parseVars(newVars);
       if (editorEnv) {
-        await apiClient.put(`/api/v1/environments/${editorEnv.id}`, {
+        await updateEnvironment(editorEnv.id, {
           name: newName.trim(),
           variables,
           is_active: editorEnv.is_active,
         });
       } else {
-        await apiClient.post('/api/v1/environments', {
-          name: newName.trim(),
-          variables,
-        });
+        await createEnvironment(newName.trim(), variables);
       }
       setShowEditor(false);
-      fetchEnvironments();
     } catch {
       // ignore
     } finally {
@@ -127,14 +96,9 @@ export default function EnvironmentSelector() {
     }
   };
 
-  const deleteEnvironment = async (id: string) => {
-    try {
-      await apiClient.delete(`/api/v1/environments/${id}`);
-      setShowEditor(false);
-      fetchEnvironments();
-    } catch {
-      // ignore
-    }
+  const handleDelete = async (id: string) => {
+    await deleteEnvironment(id);
+    setShowEditor(false);
   };
 
   return (
@@ -162,7 +126,7 @@ export default function EnvironmentSelector() {
             <div className="absolute top-full right-0 mt-1 z-50 bg-white dark:bg-surface-800 border border-surface-200 dark:border-surface-700 rounded-xl shadow-lg py-1 min-w-[180px]">
               {/* No environment option */}
               <button
-                onClick={deactivateAll}
+                onClick={handleDeactivate}
                 className={cn(
                   'w-full px-3 py-1.5 text-left text-xs flex items-center gap-2 hover:bg-surface-50 dark:hover:bg-surface-700/50',
                   !activeEnv ? 'text-brand-600 font-medium' : 'text-surface-500'
@@ -249,7 +213,8 @@ export default function EnvironmentSelector() {
                   rows={6}
                 />
                 <p className="text-[10px] text-surface-400 mt-1">
-                  {'Use {{VARIABLE_NAME}} in your requests to interpolate'}
+                  {'Use {{VARIABLE_NAME}} in your requests to interpolate.'}
+                  {' Dynamic: {{$randomUUID}}, {{$timestamp}}, {{$randomEmail}}'}
                 </p>
               </div>
             </div>
@@ -258,7 +223,7 @@ export default function EnvironmentSelector() {
               <div>
                 {editorEnv && (
                   <button
-                    onClick={() => deleteEnvironment(editorEnv.id)}
+                    onClick={() => handleDelete(editorEnv.id)}
                     className="btn-ghost !py-1.5 !px-3 !text-xs text-red-500 hover:text-red-600"
                   >
                     Delete

--- a/frontend/src/lib/interpolate.ts
+++ b/frontend/src/lib/interpolate.ts
@@ -1,0 +1,171 @@
+/**
+ * Environment variable interpolation utilities.
+ *
+ * Replaces {{VARIABLE_NAME}} placeholders in strings and objects
+ * with values from the active environment.
+ *
+ * Rules:
+ *   - Pattern: {{VARIABLE_NAME}} (double curly braces)
+ *   - Variable names: letters, digits, underscores, hyphens, dots, $-prefix for dynamic
+ *   - Unresolved variables are left as-is
+ *   - Nested interpolation is not supported
+ */
+
+/** Regex matching {{VAR_NAME}} and {{$dynamicVar}} */
+const VAR_PATTERN = /\{\{(\$?[A-Za-z0-9_.\-]+)\}\}/g;
+
+// ── Dynamic Variables ────────────────────────────────────────────────────────
+
+/**
+ * Built-in dynamic variable generators.
+ * Usage: {{$randomUUID}}, {{$timestamp}}, etc.
+ */
+const DYNAMIC_GENERATORS: Record<string, () => string> = {
+  $randomUUID: () => crypto.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  $timestamp: () => Math.floor(Date.now() / 1000).toString(),
+  $isoTimestamp: () => new Date().toISOString(),
+  $randomInt: () => Math.floor(Math.random() * 10000).toString(),
+  $randomEmail: () => `user${Math.floor(Math.random() * 99999)}@test.example.com`,
+  $randomString: () => Math.random().toString(36).slice(2, 10),
+  $randomBoolean: () => (Math.random() > 0.5 ? 'true' : 'false'),
+  $randomColor: () => '#' + Math.floor(Math.random() * 0xffffff).toString(16).padStart(6, '0'),
+  $randomIP: () => Array.from({ length: 4 }, () => Math.floor(Math.random() * 256)).join('.'),
+  $randomUserAgent: () => 'API-Watch/2.0 (automated)',
+};
+
+/** List of all supported dynamic variable names. */
+export const DYNAMIC_VARIABLE_NAMES = Object.keys(DYNAMIC_GENERATORS);
+
+/**
+ * Resolve a dynamic variable (name starting with $).
+ * Returns the generated value or undefined if not a known dynamic var.
+ */
+function resolveDynamic(name: string): string | undefined {
+  const gen = DYNAMIC_GENERATORS[name];
+  return gen ? gen() : undefined;
+}
+
+// ── Core Interpolation ──────────────────────────────────────────────────────
+
+/**
+ * Interpolate a single string: replace all {{VAR}} with values from `vars`.
+ * Dynamic variables ({{$...}}) are resolved on-the-fly.
+ * Unresolved variables are left unchanged.
+ */
+export function interpolateString(
+  input: string,
+  vars: Record<string, string>,
+): string {
+  if (!input || !input.includes('{{')) return input;
+  return input.replace(VAR_PATTERN, (match, name) => {
+    // Check user-defined variables first
+    if (name in vars) return vars[name];
+    // Then try dynamic variables
+    const dynamic = resolveDynamic(name);
+    if (dynamic !== undefined) return dynamic;
+    // Leave unresolved
+    return match;
+  });
+}
+
+/**
+ * Interpolate all string values in a flat Record<string, string>.
+ * Both keys and values are interpolated.
+ */
+export function interpolateRecord(
+  obj: Record<string, string>,
+  vars: Record<string, string>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    result[interpolateString(key, vars)] = interpolateString(value, vars);
+  }
+  return result;
+}
+
+/**
+ * Interpolate a raw body string.
+ * Handles JSON, XML, text — all treated as plain text interpolation.
+ */
+export function interpolateBody(
+  body: any,
+  vars: Record<string, string>,
+): any {
+  if (body === null || body === undefined) return body;
+
+  // String body (JSON text, XML, plain text)
+  if (typeof body === 'string') {
+    return interpolateString(body, vars);
+  }
+
+  // Object body (form-data already collapsed to Record<string,string>)
+  if (typeof body === 'object' && !Array.isArray(body)) {
+    const result: Record<string, any> = {};
+    for (const [key, value] of Object.entries(body)) {
+      const iKey = interpolateString(key, vars);
+      if (typeof value === 'string') {
+        result[iKey] = interpolateString(value, vars);
+      } else {
+        result[iKey] = value;
+      }
+    }
+    return result;
+  }
+
+  return body;
+}
+
+/**
+ * Extract all {{VAR}} names from a string.
+ */
+export function extractVariables(input: string): string[] {
+  if (!input || !input.includes('{{')) return [];
+  const names: string[] = [];
+  let match: RegExpExecArray | null;
+  const re = new RegExp(VAR_PATTERN.source, 'g');
+  while ((match = re.exec(input)) !== null) {
+    if (!names.includes(match[1])) {
+      names.push(match[1]);
+    }
+  }
+  return names;
+}
+
+/**
+ * Check which variables in a string are unresolved
+ * (not in vars dict AND not a known dynamic variable).
+ */
+export function getUnresolvedVariables(
+  input: string,
+  vars: Record<string, string>,
+): string[] {
+  return extractVariables(input).filter(
+    (name) => !(name in vars) && !(name in DYNAMIC_GENERATORS)
+  );
+}
+
+/**
+ * Returns true if the string contains any {{VAR}} pattern.
+ */
+export function hasVariables(input: string): boolean {
+  // Reset lastIndex since VAR_PATTERN has global flag
+  const re = new RegExp(VAR_PATTERN.source);
+  return re.test(input);
+}
+
+/**
+ * Preview what a string will look like after interpolation,
+ * without actually generating dynamic values.
+ * Dynamic vars show as their name, user vars show resolved values.
+ */
+export function previewInterpolation(
+  input: string,
+  vars: Record<string, string>,
+): string {
+  if (!input || !input.includes('{{')) return input;
+  return input.replace(VAR_PATTERN, (match, name) => {
+    if (name in vars) return vars[name];
+    if (name in DYNAMIC_GENERATORS) return `<${name}>`;
+    return match;
+  });
+}

--- a/frontend/src/pages/SingleRequest.tsx
+++ b/frontend/src/pages/SingleRequest.tsx
@@ -1,15 +1,29 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, useEffect, useMemo } from 'react';
 import {
   Send,
   Loader2,
   Plus,
   X,
   Copy,
+  Globe,
+  ChevronDown,
+  ChevronUp,
+  AlertTriangle,
 } from 'lucide-react';
 import { cn } from '../lib/utils';
 import apiClient from '../lib/api';
 import { useRequestStore } from '../store/useRequestStore';
 import type { HttpMethod, KeyValuePair, TabResponse, BodyType } from '../store/useRequestStore';
+import { useEnvironmentStore } from '../store/useEnvironmentStore';
+import {
+  interpolateString,
+  interpolateRecord,
+  interpolateBody,
+  hasVariables,
+  getUnresolvedVariables,
+  previewInterpolation,
+  DYNAMIC_VARIABLE_NAMES,
+} from '../lib/interpolate';
 import KeyValueEditor from '../components/KeyValueEditor';
 import BodyEditor from '../components/BodyEditor';
 import ResponseViewer from '../components/ResponseViewer';
@@ -68,10 +82,36 @@ export default function SingleRequest() {
   } = useRequestStore();
 
   const { addToHistory } = useAppStore();
+  const { activeEnv, getVariables, fetchEnvironments } = useEnvironmentStore();
   const [activePanel, setActivePanel] = useState<RequestPanel>('params');
   const [contextMenuTab, setContextMenuTab] = useState<string | null>(null);
+  const [showEnvPanel, setShowEnvPanel] = useState(false);
+
+  // Fetch environments on mount
+  useEffect(() => {
+    fetchEnvironments();
+  }, [fetchEnvironments]);
 
   const tab = getActiveTab();
+  const envVars = getVariables();
+
+  // Compute resolved URL preview
+  const resolvedUrl = useMemo(() => {
+    if (!tab.url || !hasVariables(tab.url)) return '';
+    return previewInterpolation(tab.url, envVars);
+  }, [tab.url, envVars]);
+
+  // Detect unresolved variables across all fields
+  const unresolvedVars = useMemo(() => {
+    const allText = [
+      tab.url,
+      ...tab.headers.filter(h => h.enabled).flatMap(h => [h.key, h.value]),
+      ...tab.params.filter(p => p.enabled).flatMap(p => [p.key, p.value]),
+      tab.bodyRaw,
+      ...tab.bodyFormData.filter(f => f.enabled).flatMap(f => [f.key, f.value]),
+    ].join(' ');
+    return getUnresolvedVariables(allText, envVars);
+  }, [tab, envVars]);
 
   const executeRequest = useCallback(async () => {
     if (!tab.url) return;
@@ -79,43 +119,50 @@ export default function SingleRequest() {
     setLoading(tabId, true);
 
     try {
-      const headers: Record<string, string> = {};
+      // Collect raw values
+      const rawHeaders: Record<string, string> = {};
       tab.headers
         .filter((h) => h.enabled && h.key)
-        .forEach((h) => { headers[h.key] = h.value; });
+        .forEach((h) => { rawHeaders[h.key] = h.value; });
 
-      const params: Record<string, string> = {};
+      const rawParams: Record<string, string> = {};
       tab.params
         .filter((p) => p.enabled && p.key)
-        .forEach((p) => { params[p.key] = p.value; });
+        .forEach((p) => { rawParams[p.key] = p.value; });
+
+      // Interpolate everything through the active environment
+      const finalUrl = interpolateString(tab.url, envVars);
+      const finalHeaders = interpolateRecord(rawHeaders, envVars);
+      const finalParams = interpolateRecord(rawParams, envVars);
 
       let body: any = null;
       if (tab.method !== 'GET' && tab.method !== 'HEAD') {
         if (tab.bodyType === 'json') {
-          try { body = JSON.parse(tab.bodyRaw); } catch { body = tab.bodyRaw; }
-          if (!headers['Content-Type']) headers['Content-Type'] = 'application/json';
+          const interpolated = interpolateString(tab.bodyRaw, envVars);
+          try { body = JSON.parse(interpolated); } catch { body = interpolated; }
+          if (!finalHeaders['Content-Type']) finalHeaders['Content-Type'] = 'application/json';
         } else if (tab.bodyType === 'text' || tab.bodyType === 'xml') {
-          body = tab.bodyRaw;
-          if (tab.bodyType === 'xml' && !headers['Content-Type']) {
-            headers['Content-Type'] = 'application/xml';
+          body = interpolateString(tab.bodyRaw, envVars);
+          if (tab.bodyType === 'xml' && !finalHeaders['Content-Type']) {
+            finalHeaders['Content-Type'] = 'application/xml';
           }
         } else if (tab.bodyType === 'form-data' || tab.bodyType === 'x-www-form-urlencoded') {
           const formObj: Record<string, string> = {};
           tab.bodyFormData
             .filter((f) => f.enabled && f.key)
             .forEach((f) => { formObj[f.key] = f.value; });
-          body = formObj;
-          if (tab.bodyType === 'x-www-form-urlencoded' && !headers['Content-Type']) {
-            headers['Content-Type'] = 'application/x-www-form-urlencoded';
+          body = interpolateBody(formObj, envVars);
+          if (tab.bodyType === 'x-www-form-urlencoded' && !finalHeaders['Content-Type']) {
+            finalHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
           }
         }
       }
 
       const res = await apiClient.post('/api/execute-request', {
         method: tab.method,
-        url: tab.url,
-        headers,
-        params,
+        url: finalUrl,
+        headers: finalHeaders,
+        params: finalParams,
         body,
         timeout: tab.timeout,
       });
@@ -151,7 +198,7 @@ export default function SingleRequest() {
         timestamp: new Date().toISOString(),
       });
     }
-  }, [tab, setLoading, setResponse, addToHistory]);
+  }, [tab, envVars, setLoading, setResponse, addToHistory]);
 
   const update = (updates: Partial<typeof tab>) => updateTab(tab.id, updates);
 
@@ -267,6 +314,77 @@ export default function SingleRequest() {
             <span className="hidden sm:inline">Send</span>
           </button>
         </div>
+
+        {/* Variable resolution preview */}
+        {hasVariables(tab.url) && (
+          <div className="mt-2 flex items-start gap-2">
+            <Globe className="w-3 h-3 mt-0.5 flex-shrink-0 text-brand-400" />
+            <div className="min-w-0 flex-1">
+              <p className="text-[11px] font-mono text-surface-400 truncate" title={resolvedUrl}>
+                → {resolvedUrl}
+              </p>
+              {unresolvedVars.length > 0 && (
+                <p className="text-[10px] text-amber-500 flex items-center gap-1 mt-0.5">
+                  <AlertTriangle className="w-2.5 h-2.5" />
+                  Unresolved: {unresolvedVars.join(', ')}
+                </p>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Environment Quick-View Panel */}
+      <div className="mb-3">
+        <button
+          onClick={() => setShowEnvPanel(!showEnvPanel)}
+          className={cn(
+            'flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-medium transition-colors',
+            activeEnv
+              ? 'text-emerald-600 dark:text-emerald-400 hover:bg-emerald-50 dark:hover:bg-emerald-900/10'
+              : 'text-surface-400 hover:bg-surface-100 dark:hover:bg-surface-800'
+          )}
+        >
+          <Globe className="w-3 h-3" />
+          {activeEnv ? activeEnv.name : 'No Environment'}
+          <span className="text-[10px] text-surface-400">
+            {activeEnv ? `(${Object.keys(activeEnv.variables).length} vars)` : ''}
+          </span>
+          {showEnvPanel ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
+        </button>
+
+        {showEnvPanel && (
+          <div className="mt-1 card !p-3">
+            {activeEnv && Object.keys(activeEnv.variables).length > 0 ? (
+              <div className="space-y-1">
+                <p className="text-[10px] font-semibold uppercase tracking-wider text-surface-400 mb-2">
+                  {activeEnv.name} Variables
+                </p>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1">
+                  {Object.entries(activeEnv.variables).map(([key, value]) => (
+                    <div key={key} className="flex items-baseline gap-1.5 text-[11px] font-mono">
+                      <span className="text-brand-500 dark:text-brand-400 font-medium">{`{{${key}}}`}</span>
+                      <span className="text-surface-400">=</span>
+                      <span className="text-surface-600 dark:text-surface-300 truncate" title={value}>
+                        {value.length > 40 ? value.slice(0, 40) + '…' : value}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+                <div className="border-t border-surface-100 dark:border-surface-700/50 mt-2 pt-2">
+                  <p className="text-[10px] text-surface-400">
+                    Dynamic: {DYNAMIC_VARIABLE_NAMES.slice(0, 5).map(n => `{{${n}}}`).join(', ')}
+                    {DYNAMIC_VARIABLE_NAMES.length > 5 && ` +${DYNAMIC_VARIABLE_NAMES.length - 5} more`}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <p className="text-xs text-surface-400 text-center py-2">
+                {activeEnv ? 'No variables defined in this environment' : 'Select an environment from the header to use variables'}
+              </p>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Request / Response split */}

--- a/frontend/src/store/useEnvironmentStore.ts
+++ b/frontend/src/store/useEnvironmentStore.ts
@@ -1,0 +1,121 @@
+import { create } from 'zustand';
+import apiClient from '../lib/api';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface EnvironmentEntry {
+  id: string;
+  name: string;
+  variables: Record<string, string>;
+  is_active: boolean;
+  created_at?: string;
+}
+
+// ── Store ────────────────────────────────────────────────────────────────────
+
+interface EnvironmentState {
+  /** All environments for the current user */
+  environments: EnvironmentEntry[];
+  /** The currently active environment (null = none) */
+  activeEnv: EnvironmentEntry | null;
+  /** Loading flag for initial fetch */
+  loading: boolean;
+
+  /** Fetch all environments from the API and set activeEnv */
+  fetchEnvironments: () => Promise<void>;
+
+  /** Activate a specific environment (API call + local update) */
+  activate: (env: EnvironmentEntry) => Promise<void>;
+
+  /** Deactivate the current environment */
+  deactivate: () => Promise<void>;
+
+  /** Get the variables dict of the active environment (empty object if none) */
+  getVariables: () => Record<string, string>;
+
+  /** Create a new environment */
+  createEnvironment: (name: string, variables: Record<string, string>) => Promise<void>;
+
+  /** Update an existing environment */
+  updateEnvironment: (id: string, data: Partial<Pick<EnvironmentEntry, 'name' | 'variables' | 'is_active'>>) => Promise<void>;
+
+  /** Delete an environment */
+  deleteEnvironment: (id: string) => Promise<void>;
+}
+
+export const useEnvironmentStore = create<EnvironmentState>()((set, get) => ({
+  environments: [],
+  activeEnv: null,
+  loading: false,
+
+  fetchEnvironments: async () => {
+    set({ loading: true });
+    try {
+      const res = await apiClient.get('/api/v1/environments');
+      const envs: EnvironmentEntry[] = res.data;
+      const active = envs.find((e) => e.is_active) || null;
+      set({ environments: envs, activeEnv: active, loading: false });
+    } catch {
+      set({ environments: [], activeEnv: null, loading: false });
+    }
+  },
+
+  activate: async (env) => {
+    try {
+      await apiClient.put(`/api/v1/environments/${env.id}`, {
+        name: env.name,
+        variables: env.variables,
+        is_active: true,
+      });
+      await get().fetchEnvironments();
+    } catch {
+      // ignore
+    }
+  },
+
+  deactivate: async () => {
+    const { activeEnv } = get();
+    if (!activeEnv) return;
+    try {
+      await apiClient.put(`/api/v1/environments/${activeEnv.id}`, {
+        name: activeEnv.name,
+        variables: activeEnv.variables,
+        is_active: false,
+      });
+      await get().fetchEnvironments();
+    } catch {
+      // ignore
+    }
+  },
+
+  getVariables: () => {
+    return get().activeEnv?.variables ?? {};
+  },
+
+  createEnvironment: async (name, variables) => {
+    try {
+      await apiClient.post('/api/v1/environments', { name, variables });
+      await get().fetchEnvironments();
+    } catch {
+      // ignore
+    }
+  },
+
+  updateEnvironment: async (id, data) => {
+    try {
+      await apiClient.put(`/api/v1/environments/${id}`, data);
+      await get().fetchEnvironments();
+    } catch {
+      // ignore
+    }
+  },
+
+  deleteEnvironment: async (id) => {
+    try {
+      await apiClient.delete(`/api/v1/environments/${id}`);
+      await get().fetchEnvironments();
+    } catch {
+      // ignore
+    }
+  },
+}));

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -82,6 +82,7 @@ class RequestConfigInput(BaseModel):
     params: Optional[Dict[str, str]] = {}
     body: Optional[Any] = None
     timeout: int = 10
+    env_variables: Optional[Dict[str, str]] = None  # environment variables for {{VAR}} interpolation
 
 
 class TestCaseInput(BaseModel):
@@ -104,6 +105,65 @@ class TestSuiteInput(BaseModel):
     tests: List[TestCaseInput]
 
 
+# --- Variable interpolation ---
+
+import re
+import uuid as _uuid
+import time as _time
+import random as _random
+
+_VAR_PATTERN = re.compile(r'\{\{(\$?[A-Za-z0-9_.\-]+)\}\}')
+
+_DYNAMIC_GENERATORS = {
+    '$randomUUID': lambda: str(_uuid.uuid4()),
+    '$timestamp': lambda: str(int(_time.time())),
+    '$isoTimestamp': lambda: datetime.utcnow().isoformat() + 'Z',
+    '$randomInt': lambda: str(_random.randint(0, 9999)),
+    '$randomEmail': lambda: f'user{_random.randint(0,99999)}@test.example.com',
+    '$randomString': lambda: _uuid.uuid4().hex[:8],
+    '$randomBoolean': lambda: str(_random.choice([True, False])).lower(),
+}
+
+
+def interpolate_string(text: str, variables: Dict[str, str]) -> str:
+    """Replace {{VAR}} placeholders in a string with variable values."""
+    if not text or '{{' not in text:
+        return text
+    def replacer(m):
+        name = m.group(1)
+        if name in variables:
+            return variables[name]
+        gen = _DYNAMIC_GENERATORS.get(name)
+        if gen:
+            return gen()
+        return m.group(0)  # leave unresolved
+    return _VAR_PATTERN.sub(replacer, text)
+
+
+def interpolate_dict(d: Dict[str, str], variables: Dict[str, str]) -> Dict[str, str]:
+    """Interpolate all keys and values in a dict."""
+    return {
+        interpolate_string(k, variables): interpolate_string(v, variables)
+        for k, v in d.items()
+    }
+
+
+def interpolate_body(body: Any, variables: Dict[str, str]) -> Any:
+    """Interpolate variable placeholders in a request body."""
+    if body is None:
+        return None
+    if isinstance(body, str):
+        return interpolate_string(body, variables)
+    if isinstance(body, dict):
+        return {
+            interpolate_string(str(k), variables): (
+                interpolate_string(v, variables) if isinstance(v, str) else v
+            )
+            for k, v in body.items()
+        }
+    return body
+
+
 # --- Core endpoints ---
 
 @app.get("/health")
@@ -120,15 +180,28 @@ async def execute_single_request(
 ):
     """Execute a single API request (async via httpx)."""
     try:
+        # Apply environment variable interpolation if provided
+        url = request_input.url
+        headers = request_input.headers or {}
+        params = request_input.params or {}
+        body = request_input.body
+
+        if request_input.env_variables:
+            env = request_input.env_variables
+            url = interpolate_string(url, env)
+            headers = interpolate_dict(headers, env)
+            params = interpolate_dict(params, env)
+            body = interpolate_body(body, env)
+
         retry_config = RetryConfig(max_retries=3, initial_delay=1.0)
         runner = APIRunner(auth_handler=None, retry_config=retry_config, logger=logger)
 
         config = RequestConfig(
             method=request_input.method,
-            url=request_input.url,
-            headers=request_input.headers or {},
-            params=request_input.params or {},
-            body=request_input.body,
+            url=url,
+            headers=headers,
+            params=params,
+            body=body,
             timeout=request_input.timeout,
         )
 

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -1,0 +1,105 @@
+"""
+Tests for server-side environment variable interpolation.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pytest
+from src.api_server import (
+    interpolate_string,
+    interpolate_dict,
+    interpolate_body,
+)
+
+
+class TestInterpolateString:
+    def test_replaces_known_variables(self):
+        result = interpolate_string(
+            "https://{{BASE_URL}}/users/{{USER_ID}}",
+            {"BASE_URL": "api.example.com", "USER_ID": "42"},
+        )
+        assert result == "https://api.example.com/users/42"
+
+    def test_leaves_unresolved_unchanged(self):
+        result = interpolate_string(
+            "{{BASE_URL}}/{{UNKNOWN}}",
+            {"BASE_URL": "api.example.com"},
+        )
+        assert result == "api.example.com/{{UNKNOWN}}"
+
+    def test_empty_string(self):
+        assert interpolate_string("", {"A": "B"}) == ""
+
+    def test_no_variables(self):
+        assert interpolate_string("plain text", {"A": "B"}) == "plain text"
+
+    def test_multiple_occurrences(self):
+        result = interpolate_string("{{A}}-{{A}}", {"A": "x"})
+        assert result == "x-x"
+
+    def test_dynamic_timestamp(self):
+        result = interpolate_string("ts={{$timestamp}}", {})
+        assert result.startswith("ts=")
+        assert result != "ts={{$timestamp}}"
+        # Should be a number string
+        int(result.split("=")[1])
+
+    def test_dynamic_uuid(self):
+        result = interpolate_string("id={{$randomUUID}}", {})
+        assert "{{" not in result
+        assert len(result) > 5
+
+    def test_dynamic_email(self):
+        result = interpolate_string("email={{$randomEmail}}", {})
+        assert "@test.example.com" in result
+
+    def test_user_vars_override_dynamic(self):
+        """User-defined variables should take priority over dynamic ones."""
+        result = interpolate_string(
+            "{{$timestamp}}",
+            {"$timestamp": "custom_value"},
+        )
+        assert result == "custom_value"
+
+
+class TestInterpolateDict:
+    def test_interpolates_keys_and_values(self):
+        result = interpolate_dict(
+            {"Authorization": "Bearer {{TOKEN}}", "X-User": "{{USER_ID}}"},
+            {"TOKEN": "abc123", "USER_ID": "42"},
+        )
+        assert result == {"Authorization": "Bearer abc123", "X-User": "42"}
+
+    def test_empty_dict(self):
+        assert interpolate_dict({}, {"A": "B"}) == {}
+
+    def test_no_variables_in_dict(self):
+        result = interpolate_dict({"Key": "Value"}, {"A": "B"})
+        assert result == {"Key": "Value"}
+
+
+class TestInterpolateBody:
+    def test_string_body(self):
+        result = interpolate_body('{"token": "{{TOKEN}}"}', {"TOKEN": "abc"})
+        assert result == '{"token": "abc"}'
+
+    def test_dict_body(self):
+        result = interpolate_body(
+            {"user": "{{USER}}", "count": 5},
+            {"USER": "john"},
+        )
+        assert result == {"user": "john", "count": 5}
+
+    def test_none_body(self):
+        assert interpolate_body(None, {"A": "B"}) is None
+
+    def test_non_string_values_preserved(self):
+        result = interpolate_body(
+            {"num": 42, "flag": True, "text": "{{VAR}}"},
+            {"VAR": "hello"},
+        )
+        assert result["num"] == 42
+        assert result["flag"] is True
+        assert result["text"] == "hello"


### PR DESCRIPTION
…, env quick-view)

- Add interpolation engine (frontend/src/lib/interpolate.ts) with {{VAR}} substitution
- Add dynamic variables: {{$randomUUID}}, {{$timestamp}}, {{$isoTimestamp}}, {{$randomInt}}, {{$randomEmail}}, {{$randomString}}, {{$randomBoolean}}, {{$randomColor}}, {{$randomIP}}, {{$randomUserAgent}}
- Add useEnvironmentStore (Zustand) as shared state for environments
- Refactor EnvironmentSelector to use shared store instead of local state
- Wire interpolation into SingleRequest.tsx executeRequest(): URL, headers, params, and body all interpolated through active env
- Add variable resolution preview bar below URL (shows resolved URL + unresolved warnings)
- Add collapsible environment quick-view panel showing all vars + dynamic var hints
- Add server-side interpolation: RequestConfigInput.env_variables field, interpolate_string/interpolate_dict/interpolate_body helpers in api_server.py
- Add 29 frontend tests for interpolation engine (70 total frontend tests)
- Add 16 backend tests for server-side interpolation (172 total backend tests)

## Description
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] 🧪 Tests
- [ ] 🔧 Config / CI

## Phase
<!-- Which implementation phase does this belong to? -->
- [ ] Phase 1: Foundation (DB, Async, Auth)
- [ ] Phase 2: Core UX (Tabs, Collections, Request Builder)
- [ ] Phase 3: Environments & Variables
- [ ] Phase 4: Scripting & Assertions
- [ ] Phase 5: Advanced Features
- [ ] Phase 6: Collaboration & Polish

## Changes
- 

## Testing
- [ ] Backend tests pass (`pytest`)
- [ ] Frontend tests pass (`npm test`)
- [ ] Manual testing done
- [ ] CI/CD pipeline passes

## Screenshots
<!-- If UI changes, add screenshots -->
